### PR TITLE
fix(ci): resolve tramli 3.7.1 resolution failure via Nexus credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,16 +36,21 @@ jobs:
           cache: 'maven'
 
       - name: Compile
-        run: mvn compile -q
+        run: mvn compile -q --settings .mvn/settings.xml
+        env:
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Test
-        run: mvn test -q
+        run: mvn test -q --settings .mvn/settings.xml
         env:
           DB_HOST: localhost
           DB_PORT: 5432
           DB_NAME: volta_auth_test
           DB_USER: volta
           DB_PASSWORD: volta
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
 
   docker:
     runs-on: ubuntu-latest

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven settings for CI.
+  Provides credentials for the Unlaxer Nexus repository so that
+  org.unlaxer:tramli (and other unlaxer artifacts not on Maven Central)
+  can be resolved during CI builds.
+
+  Required GitHub Actions secrets:
+    NEXUS_USERNAME  – Nexus user with read access to maven-public
+    NEXUS_PASSWORD  – Corresponding password / token
+
+  If the secrets are absent the server block is still present but
+  Maven will attempt an anonymous request, which may also succeed on
+  open Nexus instances.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0
+                              https://maven.apache.org/xsd/settings-1.2.0.xsd">
+
+  <servers>
+    <server>
+      <id>unlaxer-nexus</id>
+      <username>${env.NEXUS_USERNAME}</username>
+      <password>${env.NEXUS_PASSWORD}</password>
+    </server>
+  </servers>
+
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,20 @@
         <junit.version>5.12.2</junit.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>unlaxer-nexus</id>
+            <name>Unlaxer Nexus</name>
+            <url>https://nexus.unlaxer.org/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>io.javalin</groupId>


### PR DESCRIPTION
Closes #30

## Problem

CI was failing because `org.unlaxer:tramli:3.7.1` is not published to Maven Central, and Maven had no configured way to authenticate against the Unlaxer Nexus repository to fetch it.

## Changes

### `pom.xml`
Added a `<repositories>` block pointing to `nexus.unlaxer.org/repository/maven-public/`. This tells Maven to look at the Unlaxer Nexus for `org.unlaxer` artifacts that are not on Central.

### `.mvn/settings.xml` (new file)
Adds a Maven settings file that injects `NEXUS_USERNAME` and `NEXUS_PASSWORD` environment variables as credentials for the `unlaxer-nexus` server ID. This is required for authenticated access to Nexus from CI runners.

### `.github/workflows/ci.yml`
Both `Compile` and `Test` steps now pass `--settings .mvn/settings.xml` and expose `NEXUS_USERNAME` / `NEXUS_PASSWORD` from repository secrets.

## Required Action

Add two repository secrets in GitHub (**Settings → Secrets and variables → Actions**):
- `NEXUS_USERNAME` — Nexus user with read access to `maven-public`
- `NEXUS_PASSWORD` — Corresponding password / token

Once the secrets are set, CI will authenticate against `nexus.unlaxer.org` and successfully resolve `tramli:3.7.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)