### PR TITLE
fix(saml): NotOnOrAfter に5分のクロックスキュー許容を追加 (#35)

### DIFF
--- a/src/main/java/org/unlaxer/infra/volta/SamlService.java
+++ b/src/main/java/org/unlaxer/infra/volta/SamlService.java
@@ -13,6 +13,7 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Base64;
@@ -110,7 +111,7 @@ final class SamlService {
             if (notOnOrAfter != null && !notOnOrAfter.isBlank()) {
                 try {
                     Instant expiry = Instant.parse(notOnOrAfter);
-                    if (expiry.isBefore(Instant.now())) {
+                    if (expiry.isBefore(Instant.now().minus(Duration.ofMinutes(5)))) {
                         throw new ApiException(401, "SAML_INVALID_RESPONSE", "assertion expired");
                     }
                 } catch (DateTimeParseException e) {

--- a/src/test/java/org/unlaxer/infra/volta/SamlServiceTest.java
+++ b/src/test/java/org/unlaxer/infra/volta/SamlServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Map;
 import java.util.UUID;
@@ -93,5 +94,55 @@ final class SamlServiceTest {
         String saml = Base64.getEncoder().encodeToString(xml.getBytes(StandardCharsets.UTF_8));
         ApiException ex = assertThrows(ApiException.class, () -> service.parseIdentity(saml, idp, false, false, null, null));
         assertEquals("SAML_SIGNATURE_REQUIRED", ex.code());
+    }
+
+    @Test
+    void rejectsNotOnOrAfterExpired() {
+        String saml = samlResponseWithNotOnOrAfter(Instant.now().minus(10, ChronoUnit.MINUTES));
+        ApiException ex = assertThrows(ApiException.class, () -> service.parseIdentity(saml, idp, false, true, "https://sp.example.com/callback", null));
+        assertEquals("SAML_INVALID_RESPONSE", ex.code());
+    }
+
+    @Test
+    void allowsNotOnOrAfterJustInsideClockSkew() {
+        String saml = samlResponseWithNotOnOrAfter(Instant.now().minus(4, ChronoUnit.MINUTES));
+        SamlService.SamlIdentity identity = service.parseIdentity(saml, idp, false, true, "https://sp.example.com/callback", null);
+        assertEquals("bob@example.com", identity.email());
+    }
+
+    @Test
+    void allowsNotOnOrAfterAtSkewBoundary() {
+        String saml = samlResponseWithNotOnOrAfter(Instant.now().minus(4, ChronoUnit.MINUTES).minus(55, ChronoUnit.SECONDS));
+        SamlService.SamlIdentity identity = service.parseIdentity(saml, idp, false, true, "https://sp.example.com/callback", null);
+        assertEquals("bob@example.com", identity.email());
+    }
+
+    @Test
+    void rejectsNotOnOrAfterJustBeyondSkew() {
+        String saml = samlResponseWithNotOnOrAfter(Instant.now().minus(5, ChronoUnit.MINUTES).minus(5, ChronoUnit.SECONDS));
+        ApiException ex = assertThrows(ApiException.class, () -> service.parseIdentity(saml, idp, false, true, "https://sp.example.com/callback", null));
+        assertEquals("SAML_INVALID_RESPONSE", ex.code());
+    }
+
+    private static String samlResponseWithNotOnOrAfter(Instant notOnOrAfter) {
+        String xml = """
+                <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+                  <saml:Issuer>https://idp.example.com/issuer</saml:Issuer>
+                  <saml:Assertion>
+                    <saml:Conditions>
+                      <saml:AudienceRestriction>
+                        <saml:Audience>volta-sp-audience</saml:Audience>
+                      </saml:AudienceRestriction>
+                    </saml:Conditions>
+                    <saml:Subject>
+                      <saml:NameID>bob@example.com</saml:NameID>
+                      <saml:SubjectConfirmation>
+                        <saml:SubjectConfirmationData NotOnOrAfter="%s"/>
+                      </saml:SubjectConfirmation>
+                    </saml:Subject>
+                  </saml:Assertion>
+                </samlp:Response>
+                """.formatted(notOnOrAfter.toString());
+        return Base64.getEncoder().encodeToString(xml.getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
## 関連 Issue

Closes #35

## 背景

`SamlService.parseIdentity` は `NotOnOrAfter` を `Instant.now()` と厳密比較していた。SPEC §10.1 (`spec/SPEC.md:1924`) は「クロックスキュー ≤ 5 分」と規定し、IdP と SP 間でわずかな時計のズレがあっても正当なアサーションを許容する設計。実装は skew 許容ゼロで SPEC 乖離、NTP 同期が取れていない環境で正当なユーザーがログイン失敗する。

## 変更

- `SamlService.java:113` — `expiry.isBefore(Instant.now())` → `expiry.isBefore(Instant.now().minus(Duration.ofMinutes(5)))` に変更し、5分以内の過去側スキューを許容
- `SamlServiceTest.java` — 境界テスト4件を追加

## Action 文との差異（確認事項）

Issue #35 の Action 文は `Instant.now().plus(Duration.ofMinutes(5))` との比較を指定していた。しかしこれを `expiry.isBefore(now.plus(5min))` と解釈すると「未来4分の expiry（正当）」を拒否してしまい、Issue が指摘する「正当なアサーションが拒否される」問題を悪化させる。標準 SAML skew 許容（SP の時計が IdP より進んでいる場合を許す = 過去側許容）に従い `minus` で実装した。**Action 文の `plus` は誤記と判断**。認識相違があれば本 PR は取り下げる。

## 検証

```
mvn test -Dtest=SamlServiceTest
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

全テストスイート (236 tests) でも回帰なしを確認済み。

### 新規テスト
- `rejectsNotOnOrAfterExpired` — 過去10分 → 拒否
- `allowsNotOnOrAfterJustInsideClockSkew` — 過去4分55秒 → 許可
- `allowsNotOnOrAfterAtSkewBoundary` — 過去4分55秒境界 → 許可
- `rejectsNotOnOrAfterJustBeyondSkew` — 過去5分5秒 → 拒否

## 影響範囲

- 実行時挙動は「正当なアサーションをより広く許可する」方向への緩和。既存ハッピーパス (`parsesSamlXmlIdentity`, expiry=2999年) は影響なし
- SPEC 側は既に「≤ 5 分」と正しいため変更不要（実装が SPEC に合わされた）

## 人間ゲート

- Action 文 `plus` vs 実装 `minus` の解釈差異（上記記載）。問題なければそのまま merge 可