### PR TITLE
sec: 監査で挙がったセキュリティ4件を修正 (#33 #38 #39 #43 + #47)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,12 @@ SMTP_USER=
 SMTP_PASSWORD=
 SMTP_FROM=noreply@example.com
 SENDGRID_API_KEY=
-SAML_SKIP_SIGNATURE=true
+# ⚠ 本番では必ず false（コード側の既定も false）。
+# true にすると **IdP の署名を検証せずに SAML Response を受け入れる**ため、
+# 誰でも任意のメールアドレスでログインできる。SAML IdP を設定していない開発環境で
+# 一時的に使う場合のみ true にし、その環境が外部に出ないことを確認すること。
+# SPEC §12.3 参照。
+SAML_SKIP_SIGNATURE=false
 
 # OIDC state / RelayState の HMAC 検証に使用する鍵。
 # ⚠ 本番 (DEV_MODE=false) でデフォルト値のまま起動すると fail-fast で起動拒否します。

--- a/src/main/java/org/unlaxer/infra/volta/AdminRouter.java
+++ b/src/main/java/org/unlaxer/infra/volta/AdminRouter.java
@@ -202,6 +202,11 @@ public final class AdminRouter {
             policy.enforceMinRole(principal, "ADMIN");
             int offset = HttpSupport.parseOffset(ctx.queryParam("offset"));
             int limit = HttpSupport.parseLimit(ctx.queryParam("limit"));
+            // #39: tenantId が無い principal（service token 等）で全テナントの
+            // 監査ログが返っていた。テナントが特定できないなら見せない。
+            if (principal.tenantId() == null) {
+                throw new ApiException(403, "FORBIDDEN", "Audit log requires a tenant-scoped principal");
+            }
             List<Map<String, Object>> logs = store.listAuditLogs(principal.tenantId(), offset, limit);
             ctx.render("admin/audit.jte", model("title", "監査ログ", "logs", logs));
         });

--- a/src/main/java/org/unlaxer/infra/volta/KeyCipher.java
+++ b/src/main/java/org/unlaxer/infra/volta/KeyCipher.java
@@ -12,23 +12,54 @@ import java.util.Base64;
 public final class KeyCipher {
     private static final System.Logger LOG = System.getLogger("volta.security");
     private static final SecureRandom RANDOM = new SecureRandom();
+    /** 新規暗号化に使う鍵（v2: 600k 反復・デプロイ固有 salt）。 */
     private final SecretKeySpec keySpec;
+    /** v1 暗号文を読むためだけの鍵（100k 反復・固定 salt）。書き込みには使わない。 */
+    private final SecretKeySpec legacyKeySpec;
 
-    // Fixed salt — deterministic key derivation for the same secret.
-    // This is acceptable because the secret itself is high-entropy (from env config).
-    private static final byte[] PBKDF2_SALT = "volta-key-cipher-v2".getBytes(StandardCharsets.UTF_8);
-    private static final int PBKDF2_ITERATIONS = 100_000;
+    // ── v1（旧）: 固定 salt / 100k 反復 ────────────────────────────────
+    // 「secret が高エントロピーだから固定 salt でよい」というコメントが付いていたが、
+    // salt の役目は「同じ secret から別の鍵を導く」ことではなく
+    // **レインボーテーブルの再利用を防ぐ**こと。固定だと全デプロイで同じテーブルが
+    // 効いてしまう（#43）。復号のためだけに残す。
+    private static final byte[] PBKDF2_SALT_V1 = "volta-key-cipher-v2".getBytes(StandardCharsets.UTF_8);
+    private static final int PBKDF2_ITERATIONS_V1 = 100_000;
+
+    // ── v2（現行）: デプロイ固有 salt / 600k 反復 ──────────────────────
+    // 反復回数は OWASP 2023+ の PBKDF2-HMAC-SHA256 推奨値。
+    // salt には secret の SHA-256 を混ぜてデプロイごとに変える。
+    private static final byte[] PBKDF2_SALT_V2_PREFIX = "volta-key-cipher-v3:".getBytes(StandardCharsets.UTF_8);
+    private static final int PBKDF2_ITERATIONS_V2 = 600_000;
 
     public KeyCipher(String secret) {
         try {
-            PBEKeySpec spec = new PBEKeySpec(
-                    secret.toCharArray(), PBKDF2_SALT, PBKDF2_ITERATIONS, 256);
             SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
-            byte[] key = factory.generateSecret(spec).getEncoded();
-            this.keySpec = new SecretKeySpec(key, "AES");
+            this.keySpec = new SecretKeySpec(
+                    factory.generateSecret(new PBEKeySpec(
+                            secret.toCharArray(), saltV2(secret), PBKDF2_ITERATIONS_V2, 256)).getEncoded(),
+                    "AES");
+            this.legacyKeySpec = new SecretKeySpec(
+                    factory.generateSecret(new PBEKeySpec(
+                            secret.toCharArray(), PBKDF2_SALT_V1, PBKDF2_ITERATIONS_V1, 256)).getEncoded(),
+                    "AES");
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * デプロイ固有の salt。secret の SHA-256 を固定プレフィックスに連結する。
+     *
+     * secret 自体を salt にすると「salt が秘密」という妙な設計になるため、
+     * ハッシュを使う（salt は秘密である必要はない。デプロイごとに違えばよい）。
+     */
+    private static byte[] saltV2(String secret) throws Exception {
+        byte[] digest = java.security.MessageDigest.getInstance("SHA-256")
+                .digest(secret.getBytes(StandardCharsets.UTF_8));
+        byte[] salt = new byte[PBKDF2_SALT_V2_PREFIX.length + digest.length];
+        System.arraycopy(PBKDF2_SALT_V2_PREFIX, 0, salt, 0, PBKDF2_SALT_V2_PREFIX.length);
+        System.arraycopy(digest, 0, salt, PBKDF2_SALT_V2_PREFIX.length, digest.length);
+        return salt;
     }
 
     public String encrypt(String plain) {
@@ -38,15 +69,26 @@ public final class KeyCipher {
             Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
             cipher.init(Cipher.ENCRYPT_MODE, keySpec, new GCMParameterSpec(128, iv));
             byte[] encrypted = cipher.doFinal(plain.getBytes(StandardCharsets.UTF_8));
-            return "v1:" + b64(iv) + ":" + b64(encrypted);
+            // #43: 新規は v2（600k 反復・デプロイ固有 salt）で書く。
+            return "v2:" + b64(iv) + ":" + b64(encrypted);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
+    /**
+     * v1（旧鍵）と v2（現行鍵）の両方を読む。
+     *
+     * #43 で鍵導出を変えたため、**既存の v1 暗号文をそのままでは読めない**。
+     * 移行スクリプトを別途走らせずに済むよう、読み出しは両対応にして、書き込みは
+     * 常に v2 にする。値が更新された時点で自然に v2 へ寄る。
+     * v1 が完全に消えたと確認できたら legacyKeySpec を落とせる。
+     */
     public String decrypt(String encrypted) {
         try {
-            if (!encrypted.startsWith("v1:")) {
+            boolean v1 = encrypted.startsWith("v1:");
+            boolean v2 = encrypted.startsWith("v2:");
+            if (!v1 && !v2) {
                 LOG.log(System.Logger.Level.WARNING,
                         "KeyCipher.decrypt() received unencrypted value (legacy plaintext fallback). " +
                         "Re-encrypt this value to eliminate this warning.");
@@ -56,8 +98,12 @@ public final class KeyCipher {
             byte[] iv = Base64.getDecoder().decode(parts[1]);
             byte[] payload = Base64.getDecoder().decode(parts[2]);
             Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
-            cipher.init(Cipher.DECRYPT_MODE, keySpec, new GCMParameterSpec(128, iv));
+            cipher.init(Cipher.DECRYPT_MODE, v1 ? legacyKeySpec : keySpec, new GCMParameterSpec(128, iv));
             byte[] plain = cipher.doFinal(payload);
+            if (v1) {
+                LOG.log(System.Logger.Level.INFO,
+                        "KeyCipher: decrypted a v1 value. It will be re-encrypted as v2 on next write (#43).");
+            }
             return new String(plain, StandardCharsets.UTF_8);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/unlaxer/infra/volta/SamlService.java
+++ b/src/main/java/org/unlaxer/infra/volta/SamlService.java
@@ -60,10 +60,21 @@ final class SamlService {
             dbf.setAttribute(javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD, "");
             dbf.setAttribute(javax.xml.XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
             Document doc = dbf.newDocumentBuilder().parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+            // 署名済みで、かつ claim の抽出元にしてよい要素。
+            // skipSignature（開発用）のときは文書全体を対象にする。
+            org.w3c.dom.Element signedScope = null;
+
             if (!skipSignature) {
                 NodeList signatures = doc.getElementsByTagNameNS("*", "Signature");
                 if (signatures == null || signatures.getLength() == 0) {
                     throw new ApiException(401, "SAML_SIGNATURE_REQUIRED", "SAML signature validation is required");
+                }
+                // #33 (XSW): 署名が複数あると「どれを検証したか」と「どこから claim を
+                // 読むか」がずれる余地が生まれる。SAML Response に署名は1つで足りる
+                // （Response か Assertion のいずれか）ので、複数は拒否する。
+                if (signatures.getLength() > 1) {
+                    throw new ApiException(401, "SAML_INVALID_SIGNATURE",
+                            "multiple Signature elements are not allowed");
                 }
                 if (idp.x509Cert() == null || idp.x509Cert().isBlank()) {
                     throw new ApiException(401, "SAML_SIGNATURE_REQUIRED", "IdP certificate is required");
@@ -77,37 +88,49 @@ final class SamlService {
                 if (!valid) {
                     throw new ApiException(401, "SAML_INVALID_SIGNATURE", "SAML signature validation failed");
                 }
+
+                // #33 (XSW): 署名が通っただけでは足りない。**何に署名されたのか**を
+                // 確定し、claim はその要素の中からしか読まない。
+                //
+                // 攻撃の形: 正規の署名済み Assertion をそのまま残し、その外側に
+                // 攻撃者が作った Assertion を差し込む（signature wrapping）。署名検証は
+                // 正規部分に対して成功するので通り、後段が文書全体から
+                // getElementsByTagNameNS("*", "NameID") 等で最初の一致を拾うと
+                // **攻撃者側の値が使われる**。
+                signedScope = resolveSignedScope(doc, signature);
             }
 
-            String issuer = textOf(doc, "Issuer");
+            org.w3c.dom.Node scope = signedScope != null ? signedScope : doc;
+
+            String issuer = textOf(scope, "Issuer");
             if (idp.issuer() != null && !idp.issuer().isBlank() && !idp.issuer().equals(issuer)) {
                 throw new ApiException(401, "SAML_INVALID_RESPONSE", "issuer mismatch");
             }
-            String destination = attributeOf(doc, "Response", "Destination");
+            String destination = attributeOf(scope, "Response", "Destination");
             if (destination != null && !destination.isBlank()
                     && expectedAcsUrl != null && !expectedAcsUrl.isBlank()
                     && !expectedAcsUrl.equals(destination)) {
                 throw new ApiException(401, "SAML_INVALID_RESPONSE", "destination mismatch");
             }
-            String recipient = attributeOf(doc, "SubjectConfirmationData", "Recipient");
+            String recipient = attributeOf(scope, "SubjectConfirmationData", "Recipient");
             if (recipient != null && !recipient.isBlank()
                     && expectedAcsUrl != null && !expectedAcsUrl.isBlank()
                     && !expectedAcsUrl.equals(recipient)) {
                 throw new ApiException(401, "SAML_INVALID_RESPONSE", "recipient mismatch");
             }
-            String responseInResponseTo = attributeOf(doc, "Response", "InResponseTo");
-            String subjectInResponseTo = attributeOf(doc, "SubjectConfirmationData", "InResponseTo");
+            String responseInResponseTo = attributeOf(scope, "Response", "InResponseTo");
+            String subjectInResponseTo = attributeOf(scope, "SubjectConfirmationData", "InResponseTo");
             String inResponseTo = responseInResponseTo != null && !responseInResponseTo.isBlank() ? responseInResponseTo : subjectInResponseTo;
             if (expectedRequestId != null && !expectedRequestId.isBlank()) {
                 if (inResponseTo == null || inResponseTo.isBlank() || !expectedRequestId.equals(inResponseTo)) {
                     throw new ApiException(401, "SAML_INVALID_RESPONSE", "in_response_to mismatch");
                 }
             }
-            String audience = textOf(doc, "Audience");
+            String audience = textOf(scope, "Audience");
             if (idp.clientId() != null && !idp.clientId().isBlank() && !idp.clientId().equals(audience)) {
                 throw new ApiException(401, "SAML_INVALID_RESPONSE", "audience mismatch");
             }
-            String notOnOrAfter = attributeOf(doc, "SubjectConfirmationData", "NotOnOrAfter");
+            String notOnOrAfter = attributeOf(scope, "SubjectConfirmationData", "NotOnOrAfter");
             if (notOnOrAfter != null && !notOnOrAfter.isBlank()) {
                 try {
                     Instant expiry = Instant.parse(notOnOrAfter);
@@ -118,19 +141,19 @@ final class SamlService {
                     throw new ApiException(400, "SAML_INVALID_RESPONSE", "invalid NotOnOrAfter");
                 }
             }
-            String email = textOf(doc, "NameID");
+            String email = textOf(scope, "NameID");
             if (email == null || email.isBlank() || !email.contains("@")) {
-                email = findAttributeValue(doc, "email");
+                email = findAttributeValue(scope, "email");
             }
             if (email == null || email.isBlank() || !email.contains("@")) {
-                email = findAttributeValue(doc, "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress");
+                email = findAttributeValue(scope, "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress");
             }
             if (email == null || email.isBlank() || !email.contains("@")) {
                 throw new ApiException(401, "SAML_INVALID_RESPONSE", "email claim not found");
             }
-            String displayName = findAttributeValue(doc, "displayName");
+            String displayName = findAttributeValue(scope, "displayName");
             if (displayName == null || displayName.isBlank()) {
-                displayName = findAttributeValue(doc, "name");
+                displayName = findAttributeValue(scope, "name");
             }
             if (displayName == null || displayName.isBlank()) {
                 displayName = email.split("@")[0];
@@ -168,22 +191,23 @@ final class SamlService {
         }
     }
 
-    private static String textOf(Document doc, String localName) {
-        NodeList nodes = doc.getElementsByTagNameNS("*", localName);
+    /** #33: Document 全体ではなく「署名対象要素」を起点に探せるよう Node を取る。 */
+    private static String textOf(org.w3c.dom.Node scope, String localName) {
+        NodeList nodes = elementsIn(scope, localName);
         if (nodes == null || nodes.getLength() == 0 || nodes.item(0) == null) return null;
         String v = nodes.item(0).getTextContent();
         return v == null ? null : v.trim();
     }
 
-    private static String attributeOf(Document doc, String localName, String attributeName) {
-        NodeList nodes = doc.getElementsByTagNameNS("*", localName);
+    private static String attributeOf(org.w3c.dom.Node scope, String localName, String attributeName) {
+        NodeList nodes = elementsIn(scope, localName);
         if (nodes == null || nodes.getLength() == 0 || nodes.item(0) == null) return null;
         var attr = nodes.item(0).getAttributes() == null ? null : nodes.item(0).getAttributes().getNamedItem(attributeName);
         return attr == null ? null : attr.getTextContent();
     }
 
-    private static String findAttributeValue(Document doc, String attributeName) {
-        NodeList attributes = doc.getElementsByTagNameNS("*", "Attribute");
+    private static String findAttributeValue(org.w3c.dom.Node scope, String attributeName) {
+        NodeList attributes = elementsIn(scope, "Attribute");
         for (int i = 0; i < attributes.getLength(); i++) {
             var node = attributes.item(i);
             var nameNode = node.getAttributes() == null ? null : node.getAttributes().getNamedItem("Name");
@@ -217,4 +241,115 @@ final class SamlService {
 
     record RelayState(String tenantId, String returnTo, String requestId) {
     }
+
+    /**
+     * #33 (XSW): 検証済み署名が「何に」署名しているのかを確定する。
+     *
+     * SignedInfo の Reference URI（{@code #<ID>}）から対象要素を引き、それが
+     * Response か Assertion であることを確認して返す。空 URI（文書全体への署名）は
+     * ルート要素を対象とみなす。
+     *
+     * 判定を通らなければ 401。「署名は通ったが対象が特定できない」ものを
+     * 受け入れると、ラップされた要素から claim を読む余地が残る。
+     */
+    private static org.w3c.dom.Element resolveSignedScope(Document doc, XMLSignature signature) {
+        var references = signature.getSignedInfo().getReferences();
+        if (references == null || references.size() != 1) {
+            // SAML の Response/Assertion 署名は Reference 1本。複数あるものは
+            // 「どこまでが署名対象か」が曖昧になるので受けない。
+            throw new ApiException(401, "SAML_INVALID_SIGNATURE",
+                    "exactly one Reference is required in SignedInfo");
+        }
+        Object ref = references.get(0);
+        String uri = ((javax.xml.crypto.dsig.Reference) ref).getURI();
+
+        org.w3c.dom.Element target;
+        if (uri == null || uri.isEmpty()) {
+            // 空 URI = 文書全体（enveloped signature）
+            target = doc.getDocumentElement();
+        } else if (uri.startsWith("#")) {
+            String id = uri.substring(1);
+            target = findElementById(doc, id);
+            if (target == null) {
+                throw new ApiException(401, "SAML_INVALID_SIGNATURE",
+                        "Reference URI does not resolve to an element in this document");
+            }
+        } else {
+            // 外部参照（http://... 等）は受けない
+            throw new ApiException(401, "SAML_INVALID_SIGNATURE", "external Reference URI is not allowed");
+        }
+
+        String localName = target.getLocalName() != null ? target.getLocalName() : target.getNodeName();
+        if (!"Response".equals(localName) && !"Assertion".equals(localName)) {
+            throw new ApiException(401, "SAML_INVALID_SIGNATURE",
+                    "signature must cover Response or Assertion, got: " + localName);
+        }
+        return target;
+    }
+
+    /**
+     * ID 属性で要素を引く。
+     *
+     * {@code Document.getElementById} は DTD/スキーマで ID 型が宣言されていないと
+     * 使えない（SAML は DTD を無効化しているので常に null）。SAML の慣習である
+     * {@code ID} 属性を自前で走査する。**同じ ID が複数あれば拒否**する
+     * （ID 重複は XSW の典型的な下準備）。
+     */
+    private static org.w3c.dom.Element findElementById(Document doc, String id) {
+        NodeList all = doc.getElementsByTagName("*");
+        org.w3c.dom.Element found = null;
+        for (int i = 0; i < all.getLength(); i++) {
+            org.w3c.dom.Node node = all.item(i);
+            if (!(node instanceof org.w3c.dom.Element el)) continue;
+            var attrs = el.getAttributes();
+            if (attrs == null) continue;
+            var idAttr = attrs.getNamedItem("ID");
+            if (idAttr == null) idAttr = attrs.getNamedItem("Id");
+            if (idAttr == null) continue;
+            if (id.equals(idAttr.getTextContent())) {
+                if (found != null) {
+                    throw new ApiException(401, "SAML_INVALID_SIGNATURE",
+                            "duplicate ID in document: " + id);
+                }
+                found = el;
+            }
+        }
+        return found;
+    }
+
+    /**
+     * scope 配下の要素を localName で引く。
+     *
+     * Document を渡せば従来どおり文書全体、Element を渡せばその子孫だけを見る。
+     * #33 の要点は後者で、**署名対象の外側にある要素を claim として読まない**こと。
+     */
+    private static NodeList elementsIn(org.w3c.dom.Node scope, String localName) {
+        if (scope instanceof Document d) {
+            return d.getElementsByTagNameNS("*", localName);
+        }
+        if (scope instanceof org.w3c.dom.Element e) {
+            // scope 自身が探している要素の場合もある（Assertion 署名で Assertion を探す等）
+            String own = e.getLocalName() != null ? e.getLocalName() : e.getNodeName();
+            NodeList descendants = e.getElementsByTagNameNS("*", localName);
+            if (localName.equals(own)) {
+                return new SingleThenList(e, descendants);
+            }
+            return descendants;
+        }
+        return new SingleThenList(null, null);
+    }
+
+    /** scope 自身を先頭に、その子孫を続けて返す NodeList。 */
+    private record SingleThenList(org.w3c.dom.Element head, NodeList rest) implements NodeList {
+        @Override public org.w3c.dom.Node item(int index) {
+            if (head == null) return rest == null ? null : rest.item(index);
+            if (index == 0) return head;
+            return rest == null ? null : rest.item(index - 1);
+        }
+        @Override public int getLength() {
+            int restLen = rest == null ? 0 : rest.getLength();
+            return (head == null ? 0 : 1) + restLen;
+        }
+    }
+
 }

--- a/src/main/java/org/unlaxer/infra/volta/SqlStore.java
+++ b/src/main/java/org/unlaxer/infra/volta/SqlStore.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -1667,7 +1668,31 @@ public final class SqlStore {
         }
     }
 
+    /**
+     * 指定テナントの監査ログを返す。
+     *
+     * #39: 以前は {@code WHERE (?::uuid IS NULL OR tenant_id = ?)} で、tenantId に
+     * null を渡すと**全テナントの監査ログが返る**実装だった。呼び出し元
+     * (AdminRouter) がロールで守っているとはいえ、principal.tenantId() が null に
+     * なる経路（service token 等）が1つできた時点で cross-tenant 漏洩になる。
+     * null を拒否して、全体閲覧は {@link #listAllAuditLogs} に分離した。
+     */
     public List<Map<String, Object>> listAuditLogs(UUID tenantId, int offset, int limit) {
+        Objects.requireNonNull(tenantId, "tenantId is required (use listAllAuditLogs for cross-tenant)");
+        return queryAuditLogs(tenantId, offset, limit);
+    }
+
+    /**
+     * 全テナントの監査ログを返す。**呼び出し元で OWNER 相当を強制すること。**
+     *
+     * メソッドを分けているのは「うっかり null を渡して全件見えた」を防ぐため。
+     * 全体を見るのは意図的な操作であるべきで、引数の値で切り替わるべきではない。
+     */
+    public List<Map<String, Object>> listAllAuditLogs(int offset, int limit) {
+        return queryAuditLogs(null, offset, limit);
+    }
+
+    private List<Map<String, Object>> queryAuditLogs(UUID tenantId, int offset, int limit) {
         String sql = """
                 SELECT id, timestamp, event_type, actor_id, tenant_id, target_type, target_id, detail, request_id
                 FROM audit_logs

--- a/src/main/java/org/unlaxer/infra/volta/auth/AuthFlowHandler.java
+++ b/src/main/java/org/unlaxer/infra/volta/auth/AuthFlowHandler.java
@@ -144,16 +144,13 @@ public class AuthFlowHandler {
                 ctx.header("X-Forwarded-Proto"),
                 ctx.cookie(AuthService.SESSION_COOKIE) != null ? "present" : "absent");
 
+        // (#38) X-Forwarded-* 由来の returnTo は allowlist を通す。下の forwardedReturnTo() を使う。
         // MFA check: if session exists but MFA not verified, redirect to challenge
         if (authService.isMfaPending(ctx)) {
-            String fwdHost  = ctx.header("X-Forwarded-Host");
-            String fwdUri   = ctx.header("X-Forwarded-Uri");
-            String fwdProto = ctx.header("X-Forwarded-Proto");
-            String baseScheme = appConfig.baseUrl().startsWith("https") ? "https" : "http";
-            String proto = fwdProto != null && !"http".equals(fwdProto) ? fwdProto : baseScheme;
-            String returnTo = (fwdHost != null && fwdUri != null)
-                    ? proto + "://" + fwdHost + fwdUri
-                    : "/";
+            // #38: 以前はヘッダの値をそのまま returnTo にしていた。ヘッダ注入の
+            // 経路があると、MFA 後に任意サイトへ飛ばせる（open redirect）。
+            String validated = forwardedReturnTo(ctx);
+            String returnTo = validated != null ? validated : "/";
             LOG.log(System.Logger.Level.INFO, "[verify] MFA pending, redirecting to challenge. returnTo={0}", returnTo);
             ctx.header(AUTH_REASON_HEADER, "mfa_pending");
             ctx.redirect(appConfig.baseUrl() + "/mfa/challenge?return_to="
@@ -262,13 +259,10 @@ public class AuthFlowHandler {
         }
 
         // 2. セッションなし -> /login にリダイレクト
-        String fwdHost  = ctx.header("X-Forwarded-Host");
-        String fwdUri   = ctx.header("X-Forwarded-Uri");
-        String fwdProto = ctx.header("X-Forwarded-Proto");
-        if (fwdHost != null && fwdUri != null) {
-            String baseScheme = appConfig.baseUrl().startsWith("https") ? "https" : "http";
-            String proto = fwdProto != null && !"http".equals(fwdProto) ? fwdProto : baseScheme;
-            String returnTo = proto + "://" + fwdHost + fwdUri;
+        // #38: returnTo は allowlist 済みのものだけ使う。弾かれたら 401 に落とす
+        // （認証は要求するが、任意サイトへは飛ばさない）。
+        String returnTo = forwardedReturnTo(ctx);
+        if (returnTo != null) {
             LOG.log(System.Logger.Level.INFO, "[verify] no session → redirecting to login. returnTo={0}", returnTo);
             ctx.header(AUTH_REASON_HEADER, "cookie_absent_redirect");
             ctx.redirect(appConfig.baseUrl() + "/login?return_to="
@@ -661,4 +655,34 @@ public class AuthFlowHandler {
         ctx.header("Cache-Control", "no-store, no-cache, must-revalidate, private");
         ctx.header("Pragma", "no-cache");
     }
+
+    /**
+     * X-Forwarded-Host / -Uri / -Proto から returnTo を組み立て、allowlist を
+     * 通ったものだけ返す。通らなければ null（#38）。
+     *
+     * これらのヘッダは gateway が付ける前提だが、コード側で検証していなかった。
+     * gateway の設定を1つ間違える（trustForwardHeader を広く許す等）だけで
+     * open redirect になるため、受け取る側でも弾く。判定は
+     * {@link HttpSupport#isAllowedReturnTo} に一本化している
+     * （ALLOWED_REDIRECT_DOMAINS。ワイルドカード `*.example.org` 対応）。
+     */
+    private String forwardedReturnTo(io.javalin.http.Context ctx) {
+        String fwdHost = ctx.header("X-Forwarded-Host");
+        String fwdUri  = ctx.header("X-Forwarded-Uri");
+        if (fwdHost == null || fwdUri == null) return null;
+
+        String fwdProto = ctx.header("X-Forwarded-Proto");
+        String baseScheme = appConfig.baseUrl().startsWith("https") ? "https" : "http";
+        String proto = fwdProto != null && !"http".equals(fwdProto) ? fwdProto : baseScheme;
+        String candidate = proto + "://" + fwdHost + fwdUri;
+
+        if (!org.unlaxer.infra.volta.HttpSupport.isAllowedReturnTo(
+                candidate, appConfig.allowedRedirectDomains())) {
+            LOG.log(System.Logger.Level.WARNING,
+                    "[verify] rejected X-Forwarded returnTo (not in ALLOWED_REDIRECT_DOMAINS): {0}", candidate);
+            return null;
+        }
+        return candidate;
+    }
+
 }

--- a/src/test/java/org/unlaxer/infra/volta/KeyCipherTest.java
+++ b/src/test/java/org/unlaxer/infra/volta/KeyCipherTest.java
@@ -2,22 +2,80 @@ package org.unlaxer.infra.volta;
 
 import org.junit.jupiter.api.Test;
 
+import javax.crypto.Cipher;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class KeyCipherTest {
+    private static final String SECRET = "unit-test-secret";
+
     @Test
     void encryptDecryptRoundTrip() {
-        KeyCipher cipher = new KeyCipher("unit-test-secret");
+        KeyCipher cipher = new KeyCipher(SECRET);
         String plain = "hello-world";
         String encrypted = cipher.encrypt(plain);
         assertNotEquals(plain, encrypted);
-        assertTrue(encrypted.startsWith("v1:"));
+        // #43: 新規暗号化は v2（600k 反復 / デプロイ固有 salt）
+        assertTrue(encrypted.startsWith("v2:"), "new values must be written as v2: " + encrypted);
         assertEquals(plain, cipher.decrypt(encrypted));
     }
 
     @Test
     void decryptSupportsLegacyPlainValue() {
-        KeyCipher cipher = new KeyCipher("unit-test-secret");
+        KeyCipher cipher = new KeyCipher(SECRET);
         assertEquals("legacy", cipher.decrypt("legacy"));
+    }
+
+    /**
+     * #43: 鍵導出を変えたので、**既存の v1 暗号文が読めなくなると本番のデータが
+     * 復号不能になる**。旧方式（固定 salt / 100k 反復）で作った値を、現行コードが
+     * 読めることを固定する。
+     */
+    @Test
+    void decryptsLegacyV1CiphertextWithOldKeyDerivation() throws Exception {
+        String plain = "legacy-secret-value";
+        String v1 = encryptAsV1(SECRET, plain);
+        assertTrue(v1.startsWith("v1:"));
+
+        KeyCipher cipher = new KeyCipher(SECRET);
+        assertEquals(plain, cipher.decrypt(v1), "v1 ciphertext must still be readable");
+    }
+
+    /** salt がデプロイ固有になっているか — secret が違えば鍵も違う。 */
+    @Test
+    void differentSecretsCannotDecryptEachOther() {
+        String encrypted = new KeyCipher(SECRET).encrypt("payload");
+        KeyCipher other = new KeyCipher("another-secret");
+        assertThrows(RuntimeException.class, () -> other.decrypt(encrypted));
+    }
+
+    /** IV はランダム — 同じ平文でも毎回違う暗号文になる。 */
+    @Test
+    void sameplaintextProducesDifferentCiphertext() {
+        KeyCipher cipher = new KeyCipher(SECRET);
+        assertNotEquals(cipher.encrypt("same"), cipher.encrypt("same"));
+    }
+
+    // ── v1 形式の暗号文を作る（旧実装の再現。テスト専用） ──────────────
+    private static String encryptAsV1(String secret, String plain) throws Exception {
+        byte[] salt = "volta-key-cipher-v2".getBytes(StandardCharsets.UTF_8);
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+        byte[] key = factory.generateSecret(
+                new PBEKeySpec(secret.toCharArray(), salt, 100_000, 256)).getEncoded();
+        SecretKeySpec keySpec = new SecretKeySpec(key, "AES");
+
+        byte[] iv = new byte[12];
+        new java.security.SecureRandom().nextBytes(iv);
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, new GCMParameterSpec(128, iv));
+        byte[] encrypted = cipher.doFinal(plain.getBytes(StandardCharsets.UTF_8));
+        Base64.Encoder b64 = Base64.getEncoder();
+        return "v1:" + b64.encodeToString(iv) + ":" + b64.encodeToString(encrypted);
     }
 }


### PR DESCRIPTION
2026-08-01 のセキュリティ監査から、実害の大きい順に4件 + 設定1件。

## #33 SAML XSW — 署名位置の検証なし（High）

`getElementsByTagNameNS("*", "Signature").item(0)` で最初の署名を検証したあと、**claim は文書全体から `item(0)` で拾っていた**。正規の署名済み Assertion を残したまま、その外側に攻撃者の Assertion を差し込む signature wrapping が通る形（署名検証は正規部分で成功するので通り、claim は攻撃者側が使われる）。

人間ゲートの選択肢 (a)(b)(c) は**全部入れた**。どれか1つだけでは抜けが残るため:

| 対策 | 内容 |
|---|---|
| (a) Reference | SignedInfo の Reference は**1本のみ**許可。URI が指す要素を解決（空 URI はルート、外部参照は拒否） |
| (b) ホワイトリスト | 署名対象が **Response か Assertion** であることを確認 |
| (c) 子孫限定 | claim の抽出を**署名対象要素の子孫に限定**（`textOf` / `attributeOf` / `findAttributeValue` が Document ではなく Node を受け取る形に変更） |
| 追加 | 署名要素が**複数**あれば拒否、**ID の重複**を拒否（XSW の典型的な下準備） |

XSW ペイロードでの reject テストは、署名付き XML の生成（IdP 鍵ペアの用意）が要るのでこの PR には入れていない。**#41（UT 欠落）と合わせて次のバッチで入れる。**

## #38 X-Forwarded-Host/Uri を returnTo に無検証使用（Medium）

gateway が付けるヘッダを検証せずに `proto + "://" + fwdHost + fwdUri` を returnTo にしていた。gateway 側の設定を1つ間違える（trustForwardHeader を広く許す等）だけで open redirect になる。

`HttpSupport.isAllowedReturnTo`（`ALLOWED_REDIRECT_DOMAINS`、ワイルドカード `*.example.org` 対応）を通し、弾かれたら:
- MFA pending 側 → `"/"` にフォールバック
- セッション無し側 → **401**（認証は要求するが、任意サイトへは飛ばさない）

判定は `HttpSupport` に一本化した（`ReturnToValidator` は同種の実装だが呼び出し元が無く、ワイルドカード非対応。統合は別途）。

## #39 listAuditLogs が tenantId=null で全テナント返却（Medium）

`WHERE (?::uuid IS NULL OR tenant_id = ?)` で、null を渡すと全テナントの監査ログが返っていた。

- `listAuditLogs` は `Objects.requireNonNull(tenantId)` で null を拒否
- 全体閲覧は `listAllAuditLogs()` に分離（**引数の値で挙動が変わる形をやめる**）
- AdminRouter 側でも `principal.tenantId() == null` を 403 に

## #43 KeyCipher の PBKDF2 反復不足 + 固定 salt（Low）

100k 反復・固定 salt → **600k 反復（OWASP 2023+）・デプロイ固有 salt**（secret の SHA-256 を混ぜる）。

**移行に注意した点**: 鍵導出を変えると既存の `v1:` 暗号文が読めなくなり、本番のデータが復号不能になる。書き込みは `v2:`、読み出しは v1/v2 両対応にして、値が更新された時点で自然に v2 へ寄る形にした。v1 を読んだら INFO ログに出す。v1 が消えたと確認できたら `legacyKeySpec` を落とせる。

`KeyCipherTest` に**旧方式で作った暗号文を現行コードが読めること**を固定するテストを追加（ここが壊れると本番データが死ぬので）。

## #47 .env.example の SAML_SKIP_SIGNATURE=true

コード側の既定は既に `false`（`AppConfig.java:107`, `application.properties`）だが、`.env.example` が `true` を配っていた。これを踏むと **IdP の署名を検証せずに SAML Response を受け入れる**（誰でも任意のメールアドレスでログインできる）。`false` にし、危険性をコメントで明記。

`.env`（gitignore 済み・個人の環境設定）は触っていない。**運用者側で確認をお願いします。**

## 検証

`mvn test -DskipITs` → **246 → 249 tests、全て pass**

## この repo に残るもの

#36（RateLimiter 固定窓）/ #37（Redis 平文セッション）/ #40（例外 swallow）/ #41（UT 欠落）/ #45（maxDevices ハードコード）/ #48（.env の実シークレット）/ #49（docs）/ #50（fork PR の CI）は次のバッチ。
