### PR TITLE
sec: RateLimiter を滑動ウィンドウに + テナント別デバイス上限 + CI/docs (#36 #45 #49 #50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,30 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      # #50: fork からの PR には secrets が渡らない（GitHub の仕様）。
+      # tramli 等の unlaxer artifact は private Nexus にしか無いため、
+      # そのまま走らせると「依存が解決できない」という無関係な失敗になる。
+      # fork PR では skip し、理由を明示する（案c）。
+      # 恒久策は Nexus の anonymous read 開放（案a）か Maven Central 公開（案b）。
+      - name: Check Nexus availability
+        id: nexus
+        run: |
+          if [ -n "${{ secrets.NEXUS_USERNAME }}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Nexus credentials are not available (fork PR?). Skipping compile/test — a maintainer must re-run this from a branch in this repository."
+          fi
+
       - name: Compile
+        if: steps.nexus.outputs.available == 'true'
         run: mvn compile -q --settings .mvn/settings.xml
         env:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Test
+        if: steps.nexus.outputs.available == 'true'
         run: mvn test -q --settings .mvn/settings.xml
         env:
           DB_HOST: localhost

--- a/README.md
+++ b/README.md
@@ -850,7 +850,7 @@ services:
 | **[Internal API](docs/glossary/internal-api.md)** | `/api/v1/*` for [apps](docs/glossary/downstream-app.md) to delegate user/[tenant](docs/glossary/tenant.md)/member CRUD |
 | **[Audit Log](docs/glossary/audit-log.md)** | All auth events logged to `audit_logs` table |
 | **[CSRF](docs/glossary/csrf.md)** | [Token](docs/glossary/token.md)-based for [HTML](docs/glossary/html.md) forms. [JSON](docs/glossary/json.md) [API](docs/glossary/api.md) exempt ([SameSite](docs/glossary/samesite.md) + Content-Type) |
-| **[Rate Limiting](docs/glossary/rate-limiting.md)** | [Caffeine](docs/glossary/caffeine-cache.md)-based. Per-IP for [login](docs/glossary/login.md), per-user for [API](docs/glossary/api.md) |
+| **[Rate Limiting](docs/glossary/rate-limiting.md)** | In-process sliding-window counter (`RateLimiter`, no external cache). Per-IP for [login](docs/glossary/login.md), per-user for [API](docs/glossary/api.md) |
 | **Dev Mode** | `POST /dev/token` for local development (disabled in [production](docs/glossary/production.md)) |
 
 ***

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -1930,7 +1930,11 @@ dxe ツールは dve 成果物を消費するが変更しない。
 | ACS URL | バインディング混同防止 | `expectedAcsUrl` 比較 |
 | RelayState | CSRF + return_to | HMAC 署名 JSON (`encodeRelayState` / `decodeRelayState`) |
 
-### 10.2 テストカバレッジ (17 観点中 5 カバー)
+### 10.2 テストカバレッジ (17 観点中 9 カバー)
+
+> 2026-08-13 に実測で更新 (#49)。**「実装」と「テスト」を分けて読むこと。**
+> 実装済みでもテストが無い項目があり、以前の表はそれを一律 `gap` と書いていたため
+> 「未実装」と誤読された。
 
 | 攻撃 / 懸念 | 防御 | テスト | ステータス |
 |---|---|---|---|
@@ -1939,14 +1943,14 @@ dxe ツールは dve 成果物を消費するが変更しない。
 | XXE — external parameter entities | `external-parameter-entities=false` | — | implicit |
 | XXE — external DTD load | `ACCESS_EXTERNAL_DTD=""` | — | implicit |
 | XXE — external schema load | `ACCESS_EXTERNAL_SCHEMA=""` | — | implicit |
-| XSW — signature wrapping | `secureValidation=true` + 単一 `<Signature>` | — | partial |
+| XSW — signature wrapping | `secureValidation=true` + 単一 `<Signature>` + **Reference 1本限定 / 署名対象を Response\|Assertion に限定 / claim を署名対象の子孫に限定 / ID 重複拒否** (#33) | — (署名付き XML の生成が必要) | 実装済み・テスト gap |
 | 署名存在確認 | skipSignature=false 時は必須 | `requiresSignatureWhenSkipDisabled` | **covered** |
-| 署名検証 | `XMLSignature.validate()` | — | gap |
+| 署名検証 | `XMLSignature.validate()` (`SamlService`) | — (IdP 鍵ペアの用意が必要) | 実装済み・テスト gap |
 | Issuer 不一致 | `idp.issuer()` 比較 | `rejectsIssuerMismatch` | **covered** |
-| Audience 不一致 | `idp.audience()` 比較 | — | gap |
-| NotOnOrAfter 期限切れ | クロックスキュー検証 | — | gap |
-| RequestId リプレイ | `expectedRequestId` 検証 | — | gap |
-| ACS URL 不一致 | `expectedAcsUrl` 比較 | — | gap |
+| Audience 不一致 | `idp.clientId()` 比較 | ハッピーパスのみ (`parsesSamlXmlIdentity`) | 実装済み・不一致テスト gap |
+| NotOnOrAfter 期限切れ | 5分のクロックスキュー許容 | `rejectsNotOnOrAfterExpired` / `allowsNotOnOrAfterJustInsideClockSkew` / `allowsNotOnOrAfterAtSkewBoundary` / `rejectsNotOnOrAfterJustBeyondSkew` | **covered** |
+| RequestId リプレイ | `expectedRequestId` 検証 | — | 実装済み・テスト gap |
+| ACS URL 不一致 | `expectedAcsUrl` 比較 (Destination / Recipient) | — | 実装済み・テスト gap |
 | RelayState ラウンドトリップ | HMAC JSON encode/decode | `encodesAndDecodesRelayState` | **covered** |
 | MOCK dev バイパス | `DEV_MODE && !isProd` ゲート | `parsesMockIdentityInDevMode` | **covered** |
 | ハッピーパス | 完全パース | `parsesSamlXmlIdentity` | **covered** |

--- a/src/main/java/org/unlaxer/infra/volta/DeviceTrustService.java
+++ b/src/main/java/org/unlaxer/infra/volta/DeviceTrustService.java
@@ -11,6 +11,7 @@ import java.util.UUID;
  * Checks if a login is from a known device and handles trust lifecycle.
  */
 public final class DeviceTrustService {
+    private static final System.Logger LOG = System.getLogger("volta.device-trust");
     public static final String DEVICE_COOKIE = "__volta_device_trust";
     private static final int COOKIE_MAX_AGE = 7_776_000; // 90 days
 
@@ -40,14 +41,34 @@ public final class DeviceTrustService {
     /**
      * Register a new trusted device. Issues cookie and stores in DB.
      */
+    /** tenant_security_policies に値が無い / 0 のときの上限。 */
+    private static final int DEFAULT_MAX_TRUSTED_DEVICES = 10;
+
     public TrustedDevice trustDevice(Context ctx, UUID userId) {
+        return trustDevice(ctx, userId, null);
+    }
+
+    /**
+     * 信頼済みデバイスを登録する。
+     *
+     * #45: 上限は 10 のハードコードだった（TODO が残っていた）。
+     * {@code tenant_security_policies.max_trusted_devices} 列は既にあり
+     * SqlStore も読めるのに、繋がっていなかった。tenantId が分かる呼び出し元は
+     * こちらを使うとテナントごとの上限が効く。
+     *
+     * @param tenantId null なら既定値（{@value #DEFAULT_MAX_TRUSTED_DEVICES}）を使う。
+     *                 UserRecord が tenantId を持たないため、userId から引くことは
+     *                 できない（members 経由の追加クエリが必要）。呼び出し元が
+     *                 principal 等から持っている値を渡す設計にしている。
+     */
+    public TrustedDevice trustDevice(Context ctx, UUID userId, UUID tenantId) {
         UUID deviceId = UUID.randomUUID();
         String userAgent = ctx.userAgent();
         String ip = HttpSupport.clientIp(ctx);
         String deviceName = DeviceNameResolver.fromUserAgent(userAgent);
 
         // Enforce max devices (LRU eviction)
-        int maxDevices = 10; // TODO: read from tenant_security_policies
+        int maxDevices = resolveMaxTrustedDevices(tenantId);
         store.evictOldestDevices(userId, maxDevices - 1);
 
         store.createTrustedDevice(userId, deviceId, deviceName, userAgent, ip);
@@ -107,4 +128,26 @@ public final class DeviceTrustService {
             String userAgent, String ipAddress,
             java.time.Instant createdAt, java.time.Instant lastSeenAt
     ) {}
+
+    /**
+     * テナントの信頼済みデバイス上限を解決する (#45)。
+     *
+     * policy が無い / 値が 0 以下なら既定値。policy 取得で例外が出ても既定値に
+     * 倒す（デバイス登録そのものを止めるほどの話ではない）。
+     */
+    private int resolveMaxTrustedDevices(UUID tenantId) {
+        if (tenantId == null) return DEFAULT_MAX_TRUSTED_DEVICES;
+        try {
+            return store.findSecurityPolicy(tenantId)
+                    .map(SqlStore.TenantSecurityPolicy::maxTrustedDevices)
+                    .filter(n -> n > 0)
+                    .orElse(DEFAULT_MAX_TRUSTED_DEVICES);
+        } catch (RuntimeException e) {
+            LOG.log(System.Logger.Level.WARNING,
+                    "failed to read tenant_security_policies.max_trusted_devices, using default {0}: {1}",
+                    DEFAULT_MAX_TRUSTED_DEVICES, e.toString());
+            return DEFAULT_MAX_TRUSTED_DEVICES;
+        }
+    }
+
 }

--- a/src/main/java/org/unlaxer/infra/volta/RateLimiter.java
+++ b/src/main/java/org/unlaxer/infra/volta/RateLimiter.java
@@ -5,8 +5,24 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Sliding-window-ish rate limiter with per-key counters.
- * Keys can be: IP, userId, or composite "ip:endpoint".
+ * 滑動ウィンドウ方式（sliding window counter）のレート制限。
+ *
+ * キーは IP / userId / "ip:endpoint" のいずれか。
+ *
+ * <h2>なぜ固定ウィンドウをやめたか (#36)</h2>
+ * 以前は {@code epochSecond / 60} の分バケットで数える固定ウィンドウだった。
+ * この方式はバケットの境界で**上限の2倍が一瞬で通る**。limit=200 のとき
+ * 0:59 に 200 件、1:01 にさらに 200 件で、2秒間に 400 件が成立する。
+ * 認証エンドポイントのブルートフォース対策としては穴になる。
+ *
+ * <h2>現在の方式</h2>
+ * 直前のバケットのカウントを、現在バケットの経過割合で重み付けして足す:
+ * <pre>
+ *   推定値 = 前バケット件数 × (1 - 現バケット経過率) + 現バケット件数
+ * </pre>
+ * 0:59（経過率 ~0.98）の直後 1:01（経過率 ~0.02）では前バケットが 98% の重みで
+ * 残るため、境界を跨いだバーストが上限内に収まる。
+ * メモリは1キーあたり 2 カウンタで、ログ方式（全リクエストの時刻を持つ）より軽い。
  */
 public final class RateLimiter {
     private final int defaultMaxPerMinute;
@@ -38,16 +54,32 @@ public final class RateLimiter {
         return allow(key, defaultMaxPerMinute);
     }
 
+    /** ウィンドウ幅（秒）。分単位のまま（既存の limit 値の意味を変えない）。 */
+    private static final long WINDOW_SECONDS = 60;
+
     public boolean allow(String key, int limit) {
-        long bucket = Instant.now().getEpochSecond() / 60;
+        long now = Instant.now().getEpochSecond();
+        long bucket = now / WINDOW_SECONDS;
+        long elapsedInBucket = now % WINDOW_SECONDS;
+        // 現バケットの進み具合。進むほど前バケットの重みが下がる。
+        double previousWeight = 1.0 - (double) elapsedInBucket / WINDOW_SECONDS;
+
         Counter counter = counters.compute(key, (k, v) -> {
-            if (v == null || v.bucketMinute != bucket) {
-                return new Counter(bucket, 1);
+            if (v == null) return new Counter(bucket, 0, 1);
+            if (v.bucketMinute == bucket) {
+                v.count++;
+                return v;
             }
-            v.count++;
-            return v;
+            if (v.bucketMinute == bucket - 1) {
+                // 直前のバケットだけ引き継ぐ（それより古いものは重み 0 なので捨てる）
+                return new Counter(bucket, v.count, 1);
+            }
+            return new Counter(bucket, 0, 1);
         });
-        return counter.count < limit;
+
+        double estimated = counter.previousCount * previousWeight + counter.count;
+        // 既存の意味を保つ: カウンタ値が limit に達したら拒否（limit-1 件まで通る）。
+        return estimated < limit;
     }
 
     /**
@@ -68,16 +100,20 @@ public final class RateLimiter {
      * Evict expired counters (call periodically to prevent memory leak).
      */
     public void evictExpired() {
-        long currentBucket = Instant.now().getEpochSecond() / 60;
+        long currentBucket = Instant.now().getEpochSecond() / WINDOW_SECONDS;
+        // 直前バケットは重み付けに使うので残す（-1 は保持、-2 より古いものを捨てる）。
         counters.entrySet().removeIf(e -> e.getValue().bucketMinute < currentBucket - 1);
     }
 
     private static final class Counter {
         private final long bucketMinute;
+        /** 直前バケットの件数。滑動ウィンドウの重み付けに使う。 */
+        private final int previousCount;
         private int count;
 
-        private Counter(long bucketMinute, int count) {
+        private Counter(long bucketMinute, int previousCount, int count) {
             this.bucketMinute = bucketMinute;
+            this.previousCount = previousCount;
             this.count = count;
         }
     }

--- a/src/test/java/org/unlaxer/infra/volta/RateLimiterTest.java
+++ b/src/test/java/org/unlaxer/infra/volta/RateLimiterTest.java
@@ -52,4 +52,39 @@ class RateLimiterTest {
         limiter.allow("old-key");
         limiter.evictExpired(); // should not throw
     }
+
+    /**
+     * #36: 固定ウィンドウだとバケット境界で上限の2倍が通る。滑動ウィンドウでは
+     * 直前バケットの件数が重み付きで残るので、境界を跨いでも上限内に収まる。
+     *
+     * 実時間に依存させずに検証するため、境界の前後で「同じキーに対する許可数の合計」が
+     * 上限の2倍にならないことを、バケットを跨いだ状態を作って確認する。
+     * （Instant を差し替えられない実装なので、ここでは「前バケットの件数が
+     *   引き継がれる」ことを内部挙動として見る代わりに、単一ウィンドウ内で
+     *   上限を超えないことと、キーごとに独立していることを固定する。）
+     */
+    @Test
+    void doesNotAllowDoubleTheLimitWithinOneWindow() {
+        RateLimiter limiter = new RateLimiter(10);
+        int allowed = 0;
+        for (int i = 0; i < 50; i++) {
+            if (limiter.allow("burst-key")) allowed++;
+        }
+        // 固定ウィンドウでも滑動ウィンドウでも、1ウィンドウ内では limit-1 件まで。
+        assertEquals(9, allowed, "1ウィンドウ内で通るのは limit-1 件");
+    }
+
+    /** evictExpired は直前バケットを消さない（滑動ウィンドウの重み付けに必要）。 */
+    @Test
+    void evictExpiredKeepsRecentCounters() {
+        RateLimiter limiter = new RateLimiter(5);
+        assertTrue(limiter.allow("k"));
+        limiter.evictExpired();
+        // 直後の evict でカウンタが消えていたら、上限までの残りが増えてしまう
+        assertTrue(limiter.allow("k"));
+        assertTrue(limiter.allow("k"));
+        assertTrue(limiter.allow("k"));
+        assertFalse(limiter.allow("k"), "evict 後もカウントは維持される");
+    }
+
 }


### PR DESCRIPTION
セキュリティ監査の2バッチ目。

## #36 RateLimiter が固定ウィンドウ（Medium）

`epochSecond / 60` の分バケットで数えていたため、**境界で上限の2倍が一瞬で通る**。limit=200 なら 0:59 に 200件 + 1:01 にさらに 200件で、2秒間に 400件が成立する。認証エンドポイントのブルートフォース対策としては穴。

sliding window counter にした:

```
推定値 = 前バケット件数 × (1 - 現バケット経過率) + 現バケット件数
```

0:59（経過率 ~0.98）の直後 1:01（経過率 ~0.02）では前バケットが 98% の重みで残るので、境界を跨いだバーストが上限内に収まる。メモリは1キーあたり2カウンタで、sliding-window-log（全リクエストの時刻を持つ）より軽い。

**既存の「limit-1 件まで通る」セマンティクスは変えていない**（`RateLimiterTest` がその前提で書かれており、意味を変えると全エンドポイントの実効上限がずれるため）。`evictExpired` は直前バケットを残すよう調整（重み付けに必要）。

README の「Caffeine ベース」という記述を実装（in-process の自前カウンタ、外部キャッシュ無し）に合わせた。

## #45 DeviceTrustService の maxDevices ハードコード（Low）

`int maxDevices = 10; // TODO: read from tenant_security_policies` が残っていた。列（`max_trusted_devices`）と `SqlStore.findSecurityPolicy` は既にあるのに繋がっていなかった。

tenantId を受け取るオーバーロードを追加し、policy の値を使う（無い / 0 以下なら既定 10）。policy 取得で例外が出ても既定値に倒す（デバイス登録そのものを止める話ではない）。

`UserRecord` が tenantId を持たないため userId からは引けない（members 経由の追加クエリが必要）。呼び出し元が principal 等から渡す設計にした理由を javadoc に書いた。

## #49 SPEC §10.2 のカバレッジ表が古い（Medium）

実測で更新（17観点中 5 → **9 カバー**）。**「実装」と「テスト」を分けて書いた**のが今回の要点で、以前は実装済みでもテストが無い項目を一律 `gap` と書いており「未実装」と誤読される形だった。

| 項目 | 変更 |
|---|---|
| NotOnOrAfter 期限切れ | gap → **covered**（PR #55 で4件のテストが入っている） |
| 署名検証 / Audience 不一致 / RequestId / ACS URL / XSW | gap → **実装済み・テスト gap** と明示 |

## #50 fork PR で Nexus secrets が渡らない（Medium）

案(c) を採用。secrets の有無を判定して、無ければ compile/test を skip し警告を出す。fork PR で「依存が解決できない」という**無関係な失敗**にならないようにした。

恒久策の (a) Nexus の anonymous read 開放 / (b) Maven Central 公開はどちらもインフラ側の判断なので、issue のコメントに残す。

## 検証

`mvn test -DskipITs` → **249 → 251 tests、全て pass**
