### PR TITLE
sec: Redis セッションを保存時暗号化 + 例外の握り潰しにログを入れる (#37 #40)

### DIFF
--- a/src/main/java/org/unlaxer/infra/volta/AppConfig.java
+++ b/src/main/java/org/unlaxer/infra/volta/AppConfig.java
@@ -147,6 +147,25 @@ public record AppConfig(
     private static final String DEFAULT_JWT_KEY_ENCRYPTION_SECRET = "dev-only-secret-change-me";
     private static final String DEFAULT_AUTH_FLOW_HMAC_KEY = "dev-only-hmac-key-change-me";
 
+    /**
+     * Redis セッションの保存時暗号化に使う鍵 (#37)。
+     *
+     * {@code SESSION_ENCRYPTION_SECRET} があればそれを使い、無ければ
+     * {@code JWT_KEY_ENCRYPTION_SECRET} で代用する。新しい env を必須にすると
+     * 既存デプロイが起動しなくなるため、フォールバックを置いている。
+     * 分けておくと、セッション鍵を回しても JWT 鍵（保存済みの暗号文）に影響しない。
+     *
+     * どちらも無ければ null を返し、呼び出し側は暗号化なし（警告ログ）で動く。
+     */
+    public String sessionEncryptionSecret() {
+        String explicit = System.getenv("SESSION_ENCRYPTION_SECRET");
+        if (explicit != null && !explicit.isBlank()) return explicit;
+        if (jwtKeyEncryptionSecret != null && !jwtKeyEncryptionSecret.isBlank()) {
+            return jwtKeyEncryptionSecret;
+        }
+        return null;
+    }
+
     public boolean isJwtKeyEncryptionSecretDefault() {
         return jwtKeyEncryptionSecret == null
                 || jwtKeyEncryptionSecret.isBlank()

--- a/src/main/java/org/unlaxer/infra/volta/AuditService.java
+++ b/src/main/java/org/unlaxer/infra/volta/AuditService.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.UUID;
 
 public final class AuditService {
+    private static final System.Logger LOG = System.getLogger("volta.audit");
     private final SqlStore store;
     private final AuditSink sink;
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -85,7 +86,11 @@ public final class AuditService {
             if (metric != null && actor != null && actor.tenantId() != null) {
                 store.recordUsage(actor.tenantId(), metric, 1L, null);
             }
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            // 使用量の記録に失敗しても認証は続ける（fail-open）。ただし黙って
+            // 消すと「課金メトリクスが欠けている」ことに誰も気付けない (#40)。
+            LOG.log(System.Logger.Level.WARNING,
+                    "audit/usage recording failed (event continues): {0}", e.toString());
         }
     }
 
@@ -99,8 +104,11 @@ public final class AuditService {
             event.put("requestId", requestId != null ? requestId.toString() : null);
             event.put("ts", System.currentTimeMillis());
             authEventJedis.publish(authEventChannel, objectMapper.writeValueAsString(event));
-        } catch (Exception ignored) {
-            // Fire-and-forget: never let viz failure break auth flow
+        } catch (Exception e) {
+            // Fire-and-forget: viz の失敗で認証フローを壊さない。
+            // ただし Monitor 画面にイベントが出ない原因を追えるようログは残す (#40)。
+            LOG.log(System.Logger.Level.WARNING,
+                    "auth-event publish to Redis failed (auth flow continues): {0}", e.toString());
         }
     }
 }

--- a/src/main/java/org/unlaxer/infra/volta/AuditSink.java
+++ b/src/main/java/org/unlaxer/infra/volta/AuditSink.java
@@ -37,6 +37,7 @@ final class NoopAuditSink implements AuditSink {
 }
 
 final class KafkaAuditSink implements AuditSink {
+    private static final System.Logger LOG = System.getLogger("volta.audit-sink.kafka");
     private final KafkaProducer<String, String> producer;
     private final String topic;
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -59,7 +60,11 @@ final class KafkaAuditSink implements AuditSink {
         try {
             String payload = objectMapper.writeValueAsString(event);
             producer.send(new ProducerRecord<>(topic, payload));
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            // 監査イベントの外部送信失敗。送信できないこと自体が監査の欠落なので
+            // ログには必ず残す (#40)。
+            LOG.log(System.Logger.Level.WARNING,
+                    "audit event publish to Kafka failed (topic={0}): {1}", topic, e.toString());
         }
     }
 
@@ -71,6 +76,7 @@ final class KafkaAuditSink implements AuditSink {
 }
 
 final class ElasticsearchAuditSink implements AuditSink {
+    private static final System.Logger LOG = System.getLogger("volta.audit-sink.es");
     private final HttpClient httpClient = HttpClient.newHttpClient();
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final String endpoint;
@@ -92,7 +98,9 @@ final class ElasticsearchAuditSink implements AuditSink {
                     .POST(HttpRequest.BodyPublishers.ofString(body))
                     .build();
             httpClient.send(req, HttpResponse.BodyHandlers.discarding());
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            LOG.log(System.Logger.Level.WARNING,
+                    "audit event POST failed (endpoint={0}): {1}", endpoint, e.toString());
         }
     }
 }

--- a/src/main/java/org/unlaxer/infra/volta/AuthRouter.java
+++ b/src/main/java/org/unlaxer/infra/volta/AuthRouter.java
@@ -9,6 +9,7 @@ import java.util.*;
 import static io.javalin.rendering.template.TemplateUtil.model;
 
 public final class AuthRouter {
+    private static final System.Logger LOG = System.getLogger("volta.auth-router");
     private final AppConfig config;
     private final SqlStore store;
     private final AuthService authService;
@@ -291,7 +292,12 @@ public final class AuthRouter {
                     if (normalized.startsWith("/invite/")) {
                         safeReturnTo = normalized;
                     }
-                } catch (Exception ignored) {}
+                } catch (Exception e) {
+                    // 不正な URI は returnTo を諦めるだけ（安全側）。DEBUG に留めるのは
+                    // 攻撃者が壊れた値を投げるだけで WARNING を量産できるため (#40)。
+                    LOG.log(System.Logger.Level.DEBUG,
+                            "invalid return_to, ignoring: {0}", e.toString());
+                }
             }
 
             // Revoke session (same pattern as logout)
@@ -488,7 +494,12 @@ public final class AuthRouter {
                         String loc = geo.label();
                         if (!loc.isBlank()) data.put("location", loc);
                     });
-                } catch (Exception ignored) { /* keep email flowing */ }
+                } catch (Exception e) {
+                    // GeoIP が引けなくてもメールは送る。位置情報が常に空になる原因を
+                    // 追えるようログは残す (#40)。
+                    LOG.log(System.Logger.Level.WARNING,
+                            "GeoIP lookup failed (email continues without location): {0}", e.toString());
+                }
                 data.put("timestamp", java.time.Instant.now().toString());
                 // i18n: carry the user's stored locale (V20 users.locale)
                 // so the notification email renders in their preferred

--- a/src/main/java/org/unlaxer/infra/volta/GitHubIdp.java
+++ b/src/main/java/org/unlaxer/infra/volta/GitHubIdp.java
@@ -16,6 +16,7 @@ import java.util.Map;
  * <p>Required ENV: {@code GITHUB_CLIENT_ID}, {@code GITHUB_CLIENT_SECRET}
  */
 public final class GitHubIdp extends BaseIdpProvider {
+    private static final System.Logger LOG = System.getLogger("volta.idp.github");
 
     private static final String AUTH_URL      = "https://github.com/login/oauth/authorize";
     private static final String TOKEN_URL     = "https://github.com/login/oauth/access_token";
@@ -96,8 +97,11 @@ public final class GitHubIdp extends BaseIdpProvider {
                     return e.path("email").asText(null);
                 }
             }
-        } catch (Exception ignored) {
-            // best-effort
+        } catch (Exception e) {
+            // best-effort: primary email が取れなくてもログインは続ける。
+            // ただし「メールが空でユーザー作成に失敗する」の原因はここなので残す (#40)。
+            LOG.log(System.Logger.Level.WARNING,
+                    "GitHub primary email lookup failed: {0}", e.toString());
         }
         return null;
     }

--- a/src/main/java/org/unlaxer/infra/volta/OutboxWorker.java
+++ b/src/main/java/org/unlaxer/infra/volta/OutboxWorker.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 final class OutboxWorker implements AutoCloseable {
+    private static final System.Logger LOG = System.getLogger("volta.outbox");
     private final AppConfig config;
     private final SqlStore store;
     private final NotificationService notificationService;
@@ -40,7 +41,11 @@ final class OutboxWorker implements AutoCloseable {
             for (SqlStore.OutboxRecord outbox : pending) {
                 process(outbox);
             }
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            // ワーカーのループを止めないために飲み込む。ただし黙ると
+            // 「メールが送られていない」ことに気付けない (#40)。
+            LOG.log(System.Logger.Level.WARNING,
+                    "outbox worker iteration failed (will retry next tick): {0}", e.toString());
         }
     }
 

--- a/src/main/java/org/unlaxer/infra/volta/SessionStore.java
+++ b/src/main/java/org/unlaxer/infra/volta/SessionStore.java
@@ -45,7 +45,17 @@ interface SessionStore extends AutoCloseable {
 
     static SessionStore create(AppConfig config, SqlStore store) {
         if ("redis".equalsIgnoreCase(config.sessionStore())) {
-            return new RedisSessionStore(config.redisUrl());
+            // #37: Redis に平文 JSON で置くと csrf_token / userId / returnTo が
+            // Redis を見られる人（運用者・同一ホストの他プロセス・スナップショット）に
+            // 読める。Postgres 側は RLS (V24) で守られているが Redis は運用モデルが
+            // 違うので、保存時に暗号化する。
+            //
+            // 鍵は SESSION_ENCRYPTION_SECRET があればそれを使い、無ければ
+            // JWT_KEY_ENCRYPTION_SECRET から派生する（新しい env を必須にすると
+            // 既存デプロイが起動しなくなるため）。分離しておくと、セッション鍵を
+            // 回しても JWT 鍵に影響しない（セッションは 8h で切れるので、回した
+            // 瞬間に全員ログアウトするだけで済む）。
+            return new RedisSessionStore(config.redisUrl(), config.sessionEncryptionSecret());
         }
         return new PostgresSessionStore(store);
     }
@@ -56,6 +66,7 @@ interface SessionStore extends AutoCloseable {
 }
 
 final class PostgresSessionStore implements SessionStore {
+    private static final System.Logger LOG = System.getLogger("volta.session");
     private final SqlStore store;
 
     PostgresSessionStore(SqlStore store) {
@@ -114,11 +125,26 @@ final class PostgresSessionStore implements SessionStore {
 }
 
 final class RedisSessionStore implements SessionStore {
+    private static final System.Logger LOG = System.getLogger("volta.session.redis");
     private final JedisPooled jedis;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    /** #37: Redis に置く前に AES-GCM で暗号化する。null なら暗号化しない（後方互換）。 */
+    private final KeyCipher cipher;
 
     RedisSessionStore(String redisUrl) {
+        this(redisUrl, null);
+    }
+
+    RedisSessionStore(String redisUrl, String encryptionSecret) {
         this.jedis = new JedisPooled(URI.create(redisUrl));
+        if (encryptionSecret == null || encryptionSecret.isBlank()) {
+            this.cipher = null;
+            LOG.log(System.Logger.Level.WARNING,
+                    "session encryption is disabled: sessions will be stored in Redis as plaintext JSON. "
+                    + "Set SESSION_ENCRYPTION_SECRET or JWT_KEY_ENCRYPTION_SECRET (#37)");
+        } else {
+            this.cipher = new KeyCipher(encryptionSecret);
+        }
     }
 
     private static String skey(UUID sessionId) {
@@ -195,7 +221,11 @@ final class RedisSessionStore implements SessionStore {
             try {
                 SessionRecord rec = read(UUID.fromString(id));
                 if (rec != null) out.add(rec);
-            } catch (Exception ignored) {
+            } catch (Exception e) {
+                // 1件の読み取り失敗で一覧全体を落とさない。ただし壊れた
+                // セッションが溜まっていることに気付けるようログを残す (#40)。
+                LOG.log(System.Logger.Level.WARNING,
+                        "failed to read session {0} while listing (skipped): {1}", id, e.toString());
             }
         }
         return out;
@@ -256,7 +286,7 @@ final class RedisSessionStore implements SessionStore {
             payload.put("userAgent", rec.userAgent());
             payload.put("csrfToken", rec.csrfToken());
             String json = objectMapper.writeValueAsString(payload);
-            jedis.set(skey(rec.id()), json);
+            jedis.set(skey(rec.id()), cipher == null ? json : cipher.encrypt(json));
             long ttl = Math.max(1, rec.expiresAt().getEpochSecond() - Instant.now().getEpochSecond());
             jedis.expire(skey(rec.id()), ttl);
         } catch (Exception e) {
@@ -266,8 +296,11 @@ final class RedisSessionStore implements SessionStore {
 
     private SessionRecord read(UUID sessionId) {
         try {
-            String json = jedis.get(skey(sessionId));
-            if (json == null) return null;
+            String stored = jedis.get(skey(sessionId));
+            if (stored == null) return null;
+            // KeyCipher.decrypt は "v1:"/"v2:" 以外をそのまま返すので、
+            // 暗号化を有効にする前に書かれた平文セッションも読める（移行のため）。
+            String json = cipher == null ? stored : cipher.decrypt(stored);
             Map<?, ?> m = objectMapper.readValue(json, Map.class);
             return new SessionRecord(
                     UUID.fromString((String) m.get("id")),

--- a/src/main/java/org/unlaxer/infra/volta/flow/invite/InviteFlowRouter.java
+++ b/src/main/java/org/unlaxer/infra/volta/flow/invite/InviteFlowRouter.java
@@ -19,6 +19,7 @@ import static io.javalin.rendering.template.TemplateUtil.model;
  * Javalin routes for Invite flow via FlowEngine.
  */
 public final class InviteFlowRouter {
+    private static final System.Logger LOG = System.getLogger("volta.invite");
     private final FlowEngine engine;
     private final FlowDefinition<InviteFlowState> definition;
     private final AppConfig config;
@@ -131,7 +132,12 @@ public final class InviteFlowRouter {
             try {
                 var body = objectMapper.readTree(ctx.body());
                 flowId = body.path("flow_id").asText();
-            } catch (Exception ignored) {}
+            } catch (Exception e) {
+                // body が JSON でない場合は flow_id 無しとして進む。クライアントが
+                // 送っているつもりで届いていない、を切り分けられるよう DEBUG で残す (#40)。
+                LOG.log(System.Logger.Level.DEBUG,
+                        "invite flow_id not found in JSON body: {0}", e.toString());
+            }
         }
 
         if (flowId == null || flowId.isBlank()) {

--- a/src/main/java/org/unlaxer/infra/volta/viz/VizRouter.java
+++ b/src/main/java/org/unlaxer/infra/volta/viz/VizRouter.java
@@ -299,10 +299,15 @@ public final class VizRouter {
     /** Call from shutdown hook to cleanly stop the Redis subscribers. */
     public void close() {
         if (pubSub != null) {
-            try { pubSub.unsubscribe(); } catch (Exception ignored) {}
+            // 購読解除の失敗は接続が既に切れている場合が多い。DEBUG で足りる (#40)。
+            try { pubSub.unsubscribe(); } catch (Exception e) {
+                LOG.log(System.Logger.Level.DEBUG, "pubSub unsubscribe failed: {0}", e.toString());
+            }
         }
         if (wsPubSub != null) {
-            try { wsPubSub.unsubscribe(); } catch (Exception ignored) {}
+            try { wsPubSub.unsubscribe(); } catch (Exception e) {
+                LOG.log(System.Logger.Level.DEBUG, "wsPubSub unsubscribe failed: {0}", e.toString());
+            }
         }
     }
 
@@ -399,8 +404,11 @@ public final class VizRouter {
                             if (tenantNode != null && !tenantNode.isNull()) {
                                 row.put("tenantId", tenantNode.asText());
                             }
-                        } catch (Exception ignore) {
-                            // skip malformed context
+                        } catch (Exception e) {
+                            // 壊れた context の行はスキップする。表示が欠ける原因を
+                            // 追えるよう DEBUG で残す (#40)。
+                            LOG.log(System.Logger.Level.DEBUG,
+                                    "skipping malformed flow context: {0}", e.toString());
                         }
                     }
                     java.sql.Timestamp created = rs.getTimestamp("created_at");

--- a/src/test/java/org/unlaxer/infra/volta/RedisSessionEncryptionTest.java
+++ b/src/test/java/org/unlaxer/infra/volta/RedisSessionEncryptionTest.java
@@ -1,0 +1,81 @@
+package org.unlaxer.infra.volta;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * #37: Redis に置くセッション JSON の暗号化。
+ *
+ * Redis 本体を立てずに検証できるよう、暗号化そのものは {@link KeyCipher} に寄せて
+ * ある。ここでは「保存形式が平文でないこと」「暗号化を有効にする前に書かれた
+ * 平文セッションも読めること（移行の互換性）」を固定する。
+ *
+ * Redis 実装のラウンドトリップ（JedisPooled 経由）は testcontainers か
+ * embedded-redis の導入が前提なので #41 で扱う。
+ */
+class RedisSessionEncryptionTest {
+
+    private static final String SECRET = "session-at-rest-test-secret";
+
+    /** セッション JSON が Redis に平文で載らないこと。 */
+    @Test
+    void sessionJsonIsNotStoredInPlaintext() {
+        KeyCipher cipher = new KeyCipher(SECRET);
+        String json = """
+                {"id":"5f0f7c8e-0000-0000-0000-000000000001",
+                 "userId":"5f0f7c8e-0000-0000-0000-000000000002",
+                 "csrfToken":"super-secret-csrf",
+                 "returnTo":"/console/"}
+                """;
+
+        String stored = cipher.encrypt(json);
+
+        // Redis を覗いた人に読まれてはいけない値が、そのまま入っていないこと
+        assertFalse(stored.contains("super-secret-csrf"), "csrf_token が平文で載っている");
+        assertFalse(stored.contains("5f0f7c8e-0000-0000-0000-000000000002"), "userId が平文で載っている");
+        assertFalse(stored.contains("/console/"), "returnTo が平文で載っている");
+        assertTrue(stored.startsWith("v2:"), "暗号化形式のプレフィックスが付く: " + stored);
+
+        assertEquals(json, cipher.decrypt(stored));
+    }
+
+    /**
+     * 暗号化を有効にする前に書かれた**平文セッション**も読めること。
+     *
+     * これが壊れると、デプロイした瞬間に既存の全セッションが無効になり
+     * 全ユーザーが強制ログアウトされる。KeyCipher.decrypt が "v1:"/"v2:" 以外を
+     * そのまま返す性質に依存しているので、ここで固定する。
+     */
+    @Test
+    void plaintextSessionsWrittenBeforeEncryptionAreStillReadable() {
+        KeyCipher cipher = new KeyCipher(SECRET);
+        String legacyPlaintext = "{\"id\":\"x\",\"csrfToken\":\"t\"}";
+        assertEquals(legacyPlaintext, cipher.decrypt(legacyPlaintext));
+    }
+
+    /** 鍵が違えば読めない（Redis のダンプを持ち出しても鍵なしでは復号できない）。 */
+    @Test
+    void differentSecretCannotDecrypt() {
+        String stored = new KeyCipher(SECRET).encrypt("{\"csrfToken\":\"t\"}");
+        KeyCipher other = new KeyCipher("another-session-secret");
+        assertThrows(RuntimeException.class, () -> other.decrypt(stored));
+    }
+
+    /**
+     * 鍵が未設定なら暗号化なしで動く（起動を壊さない）。
+     *
+     * SESSION_ENCRYPTION_SECRET も JWT_KEY_ENCRYPTION_SECRET も無い環境で
+     * いきなり起動失敗にすると、既存デプロイが上がらなくなる。警告ログを出して
+     * 平文で動く、という選択をしている。
+     */
+    @Test
+    void nullSecretMeansNoEncryption() {
+        // RedisSessionStore(redisUrl, null) の分岐に相当する挙動をここで明示する。
+        // （Redis 接続を張らずに検証したいので、cipher が null のときは
+        //   「そのまま書く」ことをドキュメントとして固定する）
+        String json = "{\"csrfToken\":\"t\"}";
+        String stored = json; // cipher == null のときの write() の挙動
+        assertEquals(json, stored);
+    }
+}


### PR DESCRIPTION
## #37 Redis セッションが平文 JSON（Medium）

`csrf_token` / `userId` / `returnTo` が Redis を見られる人（運用者・同一ホストの他プロセス・スナップショット/RDB ダンプ）に読めた。Postgres 側は RLS (V24) で守られているが、Redis は運用モデルが違う。

**人間ゲート（鍵の選択）は (b) 分離 + フォールバック** にした:

| 優先 | 鍵 |
|---|---|
| 1 | `SESSION_ENCRYPTION_SECRET`（明示指定） |
| 2 | `JWT_KEY_ENCRYPTION_SECRET`（フォールバック） |
| 3 | 無し → 暗号化せずに動き、WARNING を出す |

(a) の完全共有ではなく分離にしたのは、**セッション鍵を回しても JWT 鍵（保存済みの暗号文）に影響しない**ため。セッションは 8h で切れるので、回しても全員が再ログインするだけで済みます。ただし新しい env を必須にすると既存デプロイが起動しなくなるので、未設定なら JWT 鍵から派生します。3番目の「暗号化なしで起動」を残したのも同じ理由（いきなり起動失敗にしない）。

**移行で気をつけた点**: `KeyCipher.decrypt` は `"v1:"` / `"v2:"` 以外をそのまま返すので、**暗号化を有効にする前に書かれた平文セッションもそのまま読めます**。デプロイした瞬間に全ユーザーが強制ログアウトされることはない。ここが壊れると影響が大きいのでテストで固定しました。

## #40 例外の握り潰し 13箇所（Medium）

`catch (Exception ignored) {}` でログもスタックトレースも残らない箇所を、**fail-open は維持したまま**ログを出すようにしました。レベルは実害で分けています:

| レベル | 対象 | 理由 |
|---|---|---|
| WARNING | 監査イベントの Kafka/HTTP 送信失敗、outbox のイテレーション失敗、GeoIP、usage メトリクスの欠落、壊れたセッションの読み飛ばし、GitHub primary email 取得失敗 | 気付けないと「メールが飛んでいない」「監査が欠けている」「課金メトリクスが欠けている」に直結する |
| DEBUG | 不正な `return_to`、JSON でない body、壊れた flow context、購読解除の失敗 | 攻撃者や壊れた入力で**量産できる**ので WARNING にするとログが埋まる |

実装上の注意: `AuditSink` / `SessionStore` は interface + 複数実装なので、**LOG を実装クラス側に置きました**（interface に置くと実装クラスから見えずコンパイルエラーになる）。

## 検証

`mvn test -DskipITs` → **251 → 255 tests、全て pass**

## 残り

**#41（主要クラスの UT 欠落）は open のまま**にします。今回 KeyCipher / RateLimiter / セッション暗号化で9件増やしましたが、issue が挙げている優先3ファイルのうち `AuthService` / `AuthFlowHandler` は `SqlStore`（DB 必須）に依存しており、`SessionStore` の Redis ラウンドトリップは Redis 本体が必要です。**Mockito と testcontainers（または embedded-redis）の導入判断**が前提になるので、そこは分けます。

**#58（RelayState 無署名）** は SAML 経路を閉じたので条件付き open（有効化する前に対応）。
