### PR TITLE
運用安定化・監査ログ高速化・MCP対応をまとめて反映

### DIFF
--- a/.dre/pending-decisions.json
+++ b/.dre/pending-decisions.json
@@ -203,6 +203,12 @@
       "file": "/home/opa/work/AskOS-workspace/volta-auth-proxy/docs/decisions/004-accept-tenant-scoped-mfa.md",
       "line": 36,
       "text": "## なぜ (b) を却下したか"
+    },
+    {
+      "timestamp": "2026-07-29T21:03:47Z",
+      "file": "/home/opa/work/volta-workspace/volta-auth-proxy/infra/logrotate/volta-auth-proxy",
+      "line": 8,
+      "text": "# copytruncate で inode を保ったまま切り詰める。JVM の再起動は不要。"
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ dist/
 .next/
 .nuxt/
 bower_components/
+
+# Runtime logs (start-dev.sh writes logs/auth-proxy.log; rotated by infra/logrotate)
+logs/
+
+# Local MCP server wiring (absolute paths, machine-specific)
+.mcp.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,10 @@ COPY volta-config.yaml .
 
 EXPOSE 7070
 
+# JVM メモリ上限・OOM 時の自己終了（2026-08-23/24 本番枯渇予防）。
+# mvn exec:java は maven プロセス内で実行するので MAVEN_OPTS がそのまま効く。
+# -Xmx1g の根拠: Javalin + PostgreSQL + Kafka クライアント（未実測・保守値）。
+ENV MAVEN_OPTS="-Xmx1g -XX:+ExitOnOutOfMemoryError"
+
 # -o = offline (all deps already in the image layer above)
 ENTRYPOINT ["mvn", "-o", "-q", "exec:java"]

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | [Japanese (日本語)](README.ja.md)
 
-**マルチテナント認証を、[HTTP ヘッダ](docs/glossary/header.ja.md)1つで。**
+**マルチテナント認証を、[HTTP ヘッダ](docs/glossary/header.ja.md)を読むだけで。**
 
 [マルチテナント](docs/glossary/multi-tenant.ja.md) [SaaS](docs/glossary/saas.ja.md) 向け [Identity Gateway](docs/glossary/identity-gateway.ja.md)。
 [認証](docs/glossary/authentication-vs-authorization.ja.md)・テナント管理・[ロール](docs/glossary/role.ja.md)・[招待](docs/glossary/invitation-flow.ja.md)を一手に引き受け、[下流](docs/glossary/downstream-app.ja.md)の [App](docs/glossary/downstream-app.ja.md) は何もしなくてよくなります。
@@ -55,7 +55,7 @@
 flowchart LR
     Browser --> Traefik
     Traefik -->|ForwardAuth チェック| Volta[volta-auth-proxy]
-    Volta -->|認証・テナント解決<br/>X-Volta-User-Id: abc123<br/>X-Volta-Tenant-Id: t456<br/>X-Volta-Role: MEMBER| Traefik
+    Volta -->|認証・テナント解決<br/>X-Volta-User-Id: abc123<br/>X-Volta-Tenant-Id: t456<br/>X-Volta-Roles: MEMBER| Traefik
     Traefik --> App
 ```
 
@@ -64,7 +64,7 @@ flowchart LR
 ```mermaid
 flowchart LR
     Browser --> Gateway[volta-gateway<br/>認証組み込み]
-    Gateway -->|認証・テナント解決<br/>X-Volta-User-Id: abc123<br/>X-Volta-Tenant-Id: t456<br/>X-Volta-Role: MEMBER| App
+    Gateway -->|認証・テナント解決<br/>X-Volta-User-Id: abc123<br/>X-Volta-Tenant-Id: t456<br/>X-Volta-Roles: MEMBER| App
 ```
 
 [volta-gateway](https://github.com/opaopa6969/volta-gateway) は Rust 製の[リバースプロキシ](docs/glossary/reverse-proxy.ja.md)で、volta-auth-proxy 互換の認証サーバーを内蔵しています。別途 auth-proxy を立てる必要はありません。
@@ -176,7 +176,7 @@ tramli プラグインにより、フローコードに触れずに横断的関�
 > **[tramli](https://github.com/opaopa6969/tramli)** は [Java](docs/glossary/java.ja.md) 21+ で使える独立ライブラリ。
 > 設計パターンガイド: [STATE-MACHINE-PATTERN-GUIDE.md](docs/STATE-MACHINE-PATTERN-GUIDE.md)
 
-#### OIDC ログインフロー (9状態)
+#### OIDC ログインフロー (11状態)
 
 ```mermaid
 stateDiagram-v2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | [Japanese (日本語)](README.ja.md)
 
-**[Multi-tenant](docs/glossary/multi-tenant.md) auth. One [HTTP header](docs/glossary/header.md). That's it.**
+**[Multi-tenant](docs/glossary/multi-tenant.md) auth. Your apps just read [HTTP headers](docs/glossary/header.md). That's it.**
 
 [Multi-tenant](docs/glossary/multi-tenant.md) [identity gateway](docs/glossary/identity-gateway.md) for [SaaS](docs/glossary/saas.md).
 Handles [authentication](docs/glossary/authentication-vs-authorization.md), [tenant](docs/glossary/tenant.md)s, [role](docs/glossary/role.md)s, [invitations](docs/glossary/invitation-flow.md) so [downstream](docs/glossary/downstream-app.md) apps don't have to.
@@ -55,7 +55,7 @@ Handles [authentication](docs/glossary/authentication-vs-authorization.md), [ten
 flowchart LR
     Browser --> Traefik
     Traefik -->|ForwardAuth check| Volta[volta-auth-proxy]
-    Volta -->|auth + tenant resolution<br/>X-Volta-User-Id: abc123<br/>X-Volta-Tenant-Id: t456<br/>X-Volta-Role: MEMBER| Traefik
+    Volta -->|auth + tenant resolution<br/>X-Volta-User-Id: abc123<br/>X-Volta-Tenant-Id: t456<br/>X-Volta-Roles: MEMBER| Traefik
     Traefik --> App
 ```
 
@@ -64,7 +64,7 @@ flowchart LR
 ```mermaid
 flowchart LR
     Browser --> Gateway[volta-gateway<br/>auth built-in]
-    Gateway -->|auth + tenant resolution<br/>X-Volta-User-Id: abc123<br/>X-Volta-Tenant-Id: t456<br/>X-Volta-Role: MEMBER| App
+    Gateway -->|auth + tenant resolution<br/>X-Volta-User-Id: abc123<br/>X-Volta-Tenant-Id: t456<br/>X-Volta-Roles: MEMBER| App
 ```
 
 [volta-gateway](https://github.com/opaopa6969/volta-gateway) is a Rust-based [reverse proxy](docs/glossary/reverse-proxy.md) that includes a volta-auth-proxy compatible auth server. No separate auth-proxy needed.
@@ -145,7 +145,7 @@ All flows are handled by a unified **AUTH-010 `AuthFlowHandler`** — a single e
 > **[tramli](https://github.com/opaopa6969/tramli)** is a standalone library usable in any [Java](docs/glossary/java.md) 21+ project.
 > For the design pattern guide, see [STATE-MACHINE-PATTERN-GUIDE.md](docs/STATE-MACHINE-PATTERN-GUIDE.md).
 
-#### OIDC Login Flow (9 states)
+#### OIDC Login Flow (11 states)
 
 ```mermaid
 stateDiagram-v2

--- a/README.md
+++ b/README.md
@@ -1466,6 +1466,35 @@ This project was designed using DGE (Dialogue-driven Gap Extraction) -- 106 desi
 
 ***
 
+## MCP
+
+This service exposes its REST API as MCP tools (namespace: `auth`).
+
+| | |
+|---|---|
+| **Namespace** | `auth` |
+| **Spec** | `auth://spec` (machine-readable capability list) |
+| **Guide** | `auth://guide` (M2M token → tool call flow) |
+| **Design** | [`docs/mcp/DESIGN.md`](docs/mcp/DESIGN.md) |
+| **Status** | [`docs/mcp/STATUS.md`](docs/mcp/STATUS.md) |
+| **Server** | `mcp/server.mjs` (Node, Streamable HTTP `/mcp`, port 9211) |
+| **Volta service** | `volta-auth-proxy-mcp` (host 192.168.1.8, hostname `auth-mcp.unlaxer.org`) |
+
+M2M token flow: `auth__issue_m2m_token` → JWT in subsequent tool calls.
+Destructive operations require `confirm: true` (dry-run by default).
+
+Run locally:
+```sh
+PORT=9211 node mcp/server.mjs
+```
+
+Test:
+```sh
+node mcp/test/e2e.mjs
+```
+
+***
+
 ## License
 
 TBD

--- a/deploy/volta-auth-proxy-mcp.service
+++ b/deploy/volta-auth-proxy-mcp.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=volta-auth-proxy MCP backend (namespace: auth)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/volta-auth-proxy
+Environment=PORT=9211
+Environment=AUTH_BACKEND_URL=http://127.0.0.1:7070
+EnvironmentFile=-/home/opa/volta-secrets/volta-auth-proxy-mcp.env
+ExecStart=%h/volta-auth-proxy/run.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -70,6 +70,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    mem_limit: 1536m
     environment:
       PORT:                   7070
       BASE_URL:               ${BASE_URL:-http://localhost}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   postgres:
     image: postgres:16-alpine
     container_name: volta-auth-postgres
+    restart: unless-stopped
     ports:
       - "54329:5432"
     environment:
@@ -19,6 +20,7 @@ services:
   redis:
     image: redis:7-alpine
     container_name: volta-auth-redis
+    restart: unless-stopped
     ports:
       - "6379:6379"
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ flowchart TD
     B -- yes --> C[Load session from SqlStore]
     C --> D{auth_state}
     D -- FULLY_AUTHENTICATED --> E[Check MFA scope & session TTL]
-    E -- ok --> F[200 + X-Volta-User-Id / Tenant-Id / Role / Email]
+    E -- ok --> F[200 + X-Volta-User-Id / Tenant-Id / Roles / Email]
     E -- MFA required --> G[302 /auth/mfa/challenge]
     E -- expired --> H[302 /login]
     D -- AUTHENTICATED_MFA_PENDING --> G

--- a/docs/auth-flows-ja.md
+++ b/docs/auth-flows-ja.md
@@ -176,12 +176,12 @@ sequenceDiagram
     participant B as Browser
     participant V as volta-auth-proxy
 
-    B->>V: POST /auth/passkey/register/start
+    B->>V: POST /api/v1/users/{userId}/passkeys/register/start
     V-->>B: 200 PublicKeyCredentialCreationOptions (challenge, rp, user, ...)
     B->>B: navigator.credentials.create(...)
-    B->>V: POST /auth/passkey/register/finish (attestation)
-    V->>V: Attestation 検証 (Yubico webauthn-server) ; クレデンシャル保存
-    V-->>B: 200 { ok: true }
+    B->>V: POST /api/v1/users/{userId}/passkeys/register/finish (attestation)
+    V->>V: Attestation 検証 (webauthn4j) ; クレデンシャル保存
+    V-->>B: 201 { ok: true }
 ```
 
 オーセンティケータ種別は登録時に選択可能（`0d17ce6`）。
@@ -193,11 +193,11 @@ sequenceDiagram
     participant B as Browser
     participant V as volta-auth-proxy
 
-    B->>V: POST /auth/passkey/login/start
+    B->>V: POST /auth/passkey/start
     V->>V: Passkey フロー開始 — CHALLENGE_ISSUED
     V-->>B: 200 PublicKeyCredentialRequestOptions
     B->>B: navigator.credentials.get(...)
-    B->>V: POST /auth/passkey/login/finish (assertion)
+    B->>V: POST /auth/passkey/finish (assertion)
     V->>V: [PasskeyAssertionGuard] → ASSERTION_RECEIVED
     V->>V: PasskeyVerifyProcessor → USER_RESOLVED
     V->>V: PasskeySessionProcessor → COMPLETE

--- a/docs/auth-flows.md
+++ b/docs/auth-flows.md
@@ -176,12 +176,12 @@ sequenceDiagram
     participant B as Browser
     participant V as volta-auth-proxy
 
-    B->>V: POST /auth/passkey/register/start
+    B->>V: POST /api/v1/users/{userId}/passkeys/register/start
     V-->>B: 200 PublicKeyCredentialCreationOptions (challenge, rp, user, ...)
     B->>B: navigator.credentials.create(...)
-    B->>V: POST /auth/passkey/register/finish (attestation)
-    V->>V: Verify attestation (Yubico webauthn-server) ; store credential
-    V-->>B: 200 { ok: true }
+    B->>V: POST /api/v1/users/{userId}/passkeys/register/finish (attestation)
+    V->>V: Verify attestation (webauthn4j) ; store credential
+    V-->>B: 201 { ok: true }
 ```
 
 Authenticator type is selectable at registration time (`0d17ce6`).
@@ -193,11 +193,11 @@ sequenceDiagram
     participant B as Browser
     participant V as volta-auth-proxy
 
-    B->>V: POST /auth/passkey/login/start
+    B->>V: POST /auth/passkey/start
     V->>V: Start Passkey flow — CHALLENGE_ISSUED
     V-->>B: 200 PublicKeyCredentialRequestOptions
     B->>B: navigator.credentials.get(...)
-    B->>V: POST /auth/passkey/login/finish (assertion)
+    B->>V: POST /auth/passkey/finish (assertion)
     V->>V: [PasskeyAssertionGuard] → ASSERTION_RECEIVED
     V->>V: PasskeyVerifyProcessor → USER_RESOLVED
     V->>V: PasskeySessionProcessor → COMPLETE

--- a/docs/engine-benchmark-2026-08-16.md
+++ b/docs/engine-benchmark-2026-08-16.md
@@ -1,0 +1,144 @@
+# Engine Benchmark — 2026-08-16
+
+ tramli `FlowEngine` (状態マシンエンジン) のベンチマーク改善記録。
+ 対象: `recordTransition` CPU 経路（DB 往復なし）。
+
+ ## 測定環境
+
+ - Java 21.0.9 LTS (HotSpot 64-Bit Server VM)
+ - Linux x86_64
+ - tramli 3.7.1 (jar 配布物、本体は不変)
+ - JMH は未導入のため、`System.nanoTime()` + warmup/measurement 区間分割で簡易計測
+   - DCE 対策: 結果を `volatile` シンクへ消費
+   - プロファイル汚染対策: 3 fork で中央値を採用
+   - warmup: 5 iter x 20000 ops (100K)、measure: 5 iter x 20000 ops (200K total)
+
+ ## 対象経路
+
+ `SqlFlowStore.recordTransition` が1遷移ごとに呼ぶ CPU 処理:
+ 1. `FlowDataRegistry.serialize(ctx)` — 全 FlowData を Jackson `convertValue` で Map 化
+ 2. `SensitiveRedactor.redact(serialized, registry)` — `@Sensitive` フィールドをマスキング
+ 3. `objectMapper.writeValueAsString(redacted)` — JSON 文字列化
+
+ 1 OIDC フローは5遷移するので、この経路が5回呼ばれる。
+ `SqlFlowStore.save` も `serializeContext` を呼ぶ（redact なし）ので、1 フローで合計7回の serialize。
+
+ ## 結果
+
+ ### 反復1: baseline → SensitiveRedactor リフレクションキャッシュ追加
+
+ | 指標 | baseline (元実装) | 反復1後 | 改善 |
+ |---|---|---|---|
+ | `SensitiveRedactor.redact` (ns/op) | 282,749 | 791 | **357x** |
+ | `recordTransition` CPU 経路 (ns/op) | 323,435 | 11,313 | **28.6x** |
+ | `recordTransition` CPU 経路 (ops/sec) | 3,091 | 88,393 | **28.6x** |
+
+ 元実装の `redact` は毎回 `clazz.getRecordComponents()` を呼び、各 component の `isAnnotationPresent(Sensitive.class)` をチェックしていた。クラス定義は不変なので `ConcurrentHashMap<Class<?>, Set<String>>` でキャッシュ。
+
+ ### 反復2: redactFields の不要 Map コピー削除
+
+ `@Sensitive` フィールドが無いクラスは入力 Map をそのまま返す（コピー不要）。
+
+ | 指標 | 反復1後 | 反復2後 | 改善 |
+ |---|---|---|---|
+ | `recordTransition` CPU 経路 (ns/op) | 11,313 | 11,025 | 2.5% |
+
+ 効果は微細（`redact` 自体が既に1µs以下だったため）。テスト全件通過で維持。
+
+ ### 反復3: FlowDataRegistry.serialize の TypeReference 最適化
+
+ `convertValue(value, Map.class)` を `convertValue(value, TypeReference<Map<String, Object>>)` に変更。
+ `TypeFactory.constructType(Map.class)` の per-call overhead を削減。
+
+ | 指標 | 反復2後 | 反復3後 | 改善 |
+ |---|---|---|---|
+ | `recordTransition` CPU 経路 (ns/op) | 11,025 | 10,757 | 2.4% |
+ | `recordTransition` CPU 経路 (ops/sec) | 90,700 | 92,959 | 2.5% |
+
+ ### 全体改善
+
+ | 指標 | baseline | 最終 | 改善 |
+ |---|---|---|---|
+ | `recordTransition` CPU 経路 (ns/op) | 323,435 | 10,757 | **30.1x** |
+ | `recordTransition` CPU 経路 (ops/sec) | 3,091 | 92,959 | **30.1x** |
+
+ ## InMemoryFlowStore の full flow ベンチマーク (参考)
+
+ tramli 本体の `FlowEngine` + `InMemoryFlowStore` で1フロー（startFlow + resumeAndExecute）を実行した際のスループット。
+ これは `recordTransition` の最適化とは別軸（tramli 本体のホットパス）。
+
+ | fork | ops/sec | ns/op |
+ |---|---|---|
+ | 1 | 97,587 | 10,247 |
+ | 2 | 100,535 | 9,947 |
+ | 3 | 114,930 | 8,701 |
+ | **中央値** | **100,535** | **9,947** |
+
+ JFR プロファイルで tramli 本体のホットスポット:
+ 1. `InMemoryFlowStore.create` — HashMap.put で resize 多発（flows が際限なく成長）
+ 2. `FlowContext.snapshot()` — 毎回 LinkedHashMap コピー
+ 3. `dispatchStep` 内 `transitionsFrom(state)` — stream filter + toList で毎回新 List 生成
+
+ これらは tramli 本体（jar 配布物）のため、本リポジトリからは直接変更不可。
+ `FlowDefinition` は `final class` で継承も不可。アーキテクチャ変更（tramli fork）が必要なため、今回は見送り。
+
+ ## 変更ファイル
+
+ - `src/main/java/org/unlaxer/infra/volta/flow/SensitiveRedactor.java` (+37/-15)
+   - `ConcurrentHashMap<Class<?>, Set<String>>` で `@Sensitive` フィールド名をキャッシュ
+   - `redactFields` で sensitive 無しクラスは Map コピーを省略
+ - `src/main/java/org/unlaxer/infra/volta/flow/FlowDataRegistry.java` (+6/-1)
+   - `TypeReference<Map<String, Object>>` を static final で保持し `convertValue` の型構築 overhead を削減
+
+ ## テスト
+
+ - `SensitiveRedactorTest` (2件) — 全通過
+ - `FlowDataRegistryTest` (5件) — 全通過
+ - `RiskAndMfaBranchTest` (5件) — 全通過
+ - `OidcFlowDefTest` (4件) — 環境制約（Nexus依存の propstack 未解決）で未検証。変更とは無関係。
+
+ ## 外部データの出典・ライセンス
+
+ | # | URL | 取得日 | ライセンス |
+ |---|-----|--------|-----------|
+ | 1 | https://github.com/hekailiang/squirrel (README, User Guide) | 2026-08-16 | Apache License 2.0 |
+ | 2 | https://doc.akka.io/libraries/akka-core/current/typed/fsm.html | 2026-08-16 | Business Source License 1.1 (© 2011-2026 Lightbend) |
+ | 3 | https://docs.spring.io/spring-statemachine/docs/current/reference/ | 2026-08-16 | Apache 2.0 (spring-attic, 2026-07-05アーカイブ) |
+ | 4 | https://github.com/spring-attic/spring-statemachine | 2026-08-16 | Apache 2.0 |
+ | 5 | https://openjdk.java.net/projects/code-tools/jmh/ | 2026-08-16 | GPLv2 (OpenJDK) |
+ | 6 | https://github.com/openjdk/jmh (README, LICENSE) | 2026-08-16 | GPL-2.0-only |
+ | 7 | https://github.com/openjdk/jmh/tree/master/jmh-samples/src/main/java/org/openjdk/jmh/samples | 2026-08-16 | GPL-2.0 |
+ | 8 | https://github.com/openjdk/jmh/blob/master/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_01_HelloWorld.java | 2026-08-16 | GPL-2.0 |
+ | 9 | https://github.com/openjdk/jmh/blob/master/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_08_DeadCode.java | 2026-08-16 | GPL-2.0 |
+ | 10 | https://github.com/openjdk/jmh/blob/master/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_09_Blackholes.java | 2026-08-16 | GPL-2.0 |
+ | 11 | https://github.com/openjdk/jmh/blob/master/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_11_Loops.java | 2026-08-16 | GPL-2.0 |
+ | 12 | https://github.com/openjdk/jmh/blob/master/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_12_Forking.java | 2026-08-16 | GPL-2.0 |
+ | 13 | https://github.com/openjdk/jmh/blob/master/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_13_RunToRun.java | 2026-08-16 | GPL-2.0 |
+ | 14 | https://www.postgresql.org/docs/current/explicit-locking.html | 2026-08-16 | PostgreSQL License (© 1996-2026 PostgreSQL Global Development Group) |
+ | 15 | https://www.postgresql.org/docs/current/datatype-json.html | 2026-08-16 | PostgreSQL License |
+ | 16 | https://www.postgresql.org/docs/current/pgbench.html | 2026-08-16 | PostgreSQL License |
+
+ ## 再現手順
+
+ ```bash
+ # クラスパス構築（mvn が無い環境向け）
+ CP="target/classes:target/test-classes"
+ CP="$CP:/home/opa/.m2/repository/org/unlaxer/tramli/3.7.1/tramli-3.7.1.jar"
+ # jackson
+ for j in jackson-databind jackson-core jackson-annotations; do
+   CP="$CP:$(find ~/.m2/repository -name "${j}-2.18.4.jar" | head -1)"
+ done
+ CP="$CP:$(find ~/.m2/repository -name 'jackson-datatype-jsr310-2.18.4.jar' | head -1)"
+ # slf4j, junit, nimbus, propstack 等（テスト用）
+
+ # ベンチマークコンパイル・実行
+ javac -cp "$CP" -d /tmp/bench /tmp/bench/BenchRedactOpt.java
+ java -cp "$CP:/tmp/bench" BenchRedactOpt
+ ```
+
+ ## 次の判断（人間ゲート候補）
+
+ 1. **tramli 本体の最適化**（`FlowDefinition.transitionsFrom` のキャッシュ、`InMemoryFlowStore` の容量上限）は、tramli リポジトリの fork が必要。アーキテクチャ変更に該当するため要判断。
+ 2. **`SqlFlowStore` の `recordTransition` バッチ化**（5遷移分の INSERT を1トランザクションにまとめる）は、監査ログの即時永続性を低下させるため、運用要件の確認が必要。
+ 3. **JMH の正式導入**（`pom.xml` に `jmh-core` 依存追加）は、ビルド設定変更。ベンチマーク精度を上げるなら推奨。
+ 4. **PostgreSQL 実環境でのベンチマーク**は、`docker-compose up -d` でDBを立てて `SqlFlowStore` 経路を測定する必要がある。今回は環境制約で未実施。

--- a/docs/getting-started-ja.md
+++ b/docs/getting-started-ja.md
@@ -232,9 +232,10 @@ PASSKEY_RP_ID=auth.example.com      # ブラウザがクレデンシャルを結
 PASSKEY_RP_NAME="Example Inc."
 ```
 
-`POST /auth/passkey/register/start` → ブラウザ WebAuthn セレモニー →
-`POST /auth/passkey/register/finish` でクレデンシャル登録。オーセンティケータ
-種別は登録時に選択可能（`0d17ce6`）。
+認証済みユーザーが `POST /api/v1/users/{userId}/passkeys/register/start` →
+ブラウザ WebAuthn セレモニー →
+`POST /api/v1/users/{userId}/passkeys/register/finish` でクレデンシャル登録。
+オーセンティケータ種別は `?type=platform` または `?type=cross-platform` で選択可能。
 
 ## MFA (TOTP) 有効化
 
@@ -243,8 +244,9 @@ MFA_ENABLED=true
 MFA_ISSUER="Example Inc."
 ```
 
-`POST /auth/mfa/setup` で QR 発行、`POST /auth/mfa/verify` で確認。MFA フローは
-4 状態の tramli FlowDefinition ——
+`POST /api/v1/users/{userId}/mfa/totp/setup` で QR 発行、
+`POST /api/v1/users/{userId}/mfa/totp/verify` で TOTP を確認する。MFA チャレンジは
+`POST /auth/mfa/verify`。MFA フローは 4 状態の tramli FlowDefinition ——
 [architecture-ja.md](architecture-ja.md#mfa-flow-tramli) 参照。
 
 > **ADR-004**: MFA は *テナントスコープ*。テナント切替で再検証が走る。
@@ -255,7 +257,7 @@ MFA_ISSUER="Example Inc."
 
 ```bash
 # 1. ヘルスチェック
-curl -s http://localhost:7070/health | jq .
+curl -s http://localhost:7070/healthz | jq .
 
 # 2. ForwardAuth（未認証 → 302）
 curl -i -H "X-Forwarded-Host: app.example.com" \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -233,9 +233,10 @@ PASSKEY_RP_ID=auth.example.com      # the RP ID the browser binds credentials to
 PASSKEY_RP_NAME="Example Inc."
 ```
 
-Users register credentials via `POST /auth/passkey/register/start` → browser
-WebAuthn ceremony → `POST /auth/passkey/register/finish`. Authenticator type is
-selectable at registration (`0d17ce6`).
+Authenticated users register credentials via `POST /api/v1/users/{userId}/passkeys/register/start`
+→ browser WebAuthn ceremony → `POST /api/v1/users/{userId}/passkeys/register/finish`.
+Authenticator type is selectable at registration (`?type=platform` or
+`?type=cross-platform`).
 
 ## Enabling MFA (TOTP)
 
@@ -244,8 +245,9 @@ MFA_ENABLED=true
 MFA_ISSUER="Example Inc."
 ```
 
-Users enroll via `POST /auth/mfa/setup`, scan a QR code, and confirm with
-`POST /auth/mfa/verify`. The MFA flow is a 4-state tramli FlowDefinition — see
+Users enroll via `POST /api/v1/users/{userId}/mfa/totp/setup`, scan a QR code, and
+confirm with `POST /api/v1/users/{userId}/mfa/totp/verify`. The MFA challenge
+flow uses `POST /auth/mfa/verify`. It is a 4-state tramli FlowDefinition — see
 [architecture.md](architecture.md#mfa-flow-tramli).
 
 > **ADR-004**: MFA verification is *tenant-scoped*. Switching tenants forces a
@@ -257,7 +259,7 @@ Users enroll via `POST /auth/mfa/setup`, scan a QR code, and confirm with
 
 ```bash
 # 1. Health
-curl -s http://localhost:7070/health | jq .
+curl -s http://localhost:7070/healthz | jq .
 
 # 2. ForwardAuth (unauthenticated → 302)
 curl -i -H "X-Forwarded-Host: app.example.com" \

--- a/docs/market/2026-07-31.md
+++ b/docs/market/2026-07-31.md
@@ -1,0 +1,147 @@
+---
+kind: market-research
+repo: opaopa6969/volta-auth-proxy
+target_type: hybrid
+surveyed_at: 2026-07-31
+surveyed_by: gpt-5
+commit: 7e6373473879aad813767a102ab908a2671d51df
+verdict: SaaS向けForwardAuthに絞った実装優位
+confidence: 高
+focus: null
+next_review: 2026-10-31
+review_trigger:
+  - 自repoに公開機能が入ったとき
+  - 比較対象にメジャーリリースがあったとき
+  - 本番運用または採用実績が確認できたとき
+products:
+  - { name: Keycloak, url: 'https://github.com/keycloak/keycloak', stars: 35900, license: Apache-2.0, checked_at: 2026-07-31 }
+  - { name: authentik, url: 'https://github.com/goauthentik/authentik', stars: 21700, license: '詳しいライセンス表記を本調査では確定できず', checked_at: 2026-07-31 }
+  - { name: ZITADEL, url: 'https://github.com/zitadel/zitadel', stars: 14600, license: AGPL-3.0, checked_at: 2026-07-31 }
+  - { name: Ory Kratos, url: 'https://github.com/ory/kratos', stars: 13800, license: Apache-2.0, checked_at: 2026-07-31 }
+---
+
+# 市場調査: volta-auth-proxy
+
+## 0. 要約
+
+立ち位置: SaaSの下流アプリをHTTPヘッダだけでマルチテナント認証できる、コード管理型の自己ホスト認証ゲートウェイ。
+
+最大の弱点: 大手OSSに比べて採用実績・運用実績・周辺エコシステムが見えず、本番で任せられる証拠が不足している。
+
+次の一手: 機能追加より、再現可能なデプロイ、脅威モデル、外部公開の検証結果を一つの導入パッケージとして示す。
+
+## 1. このrepoは何か
+
+volta-auth-proxy は、Traefik ForwardAuth または Nginx `auth_request` の前段に置く、Java 21/Javalin 製の自己ホスト型認証ゲートウェイである。リクエストごとにセッションを検証し、ユーザー・テナント・ロールを `X-Volta-*` ヘッダで下流アプリへ渡す。下流アプリはパスワード、SAML assertion、MFA secret を扱わない。
+
+したがって比較単位は Java の認証ライブラリではなく、「SaaS向けの認証・テナント管理・下流連携をまとめて置き換える基盤」である。価値は本repo単体だけでなく、Traefik/Nginx（または volta-gateway）と下流アプリを組み合わせて発生する。
+
+実装上は OIDC、SAML、TOTP MFA、Passkey、招待、SCIM、M2M OAuth、Webhook outbox、監査 sink、GDPR データ操作、ロール/ポリシー制御を含む。認証フローは tramli の state machine として Java コードで定義され、ビルド時検証・Mermaid図生成・テストを組み合わせている。
+
+確認できた客観指標は、Java本体104ファイル・16,872行、テスト42ファイル・2,938行、JTEテンプレート21、Maven dependency宣言22件、`mvn -q test` 成功、調査時点の HEAD `7e63734` である。公開サイトの稼働状況、利用社数、SLA、本番トラフィックは確認できない。
+
+## 1.5 調査の型
+
+`hybrid` とした。ソースコードとテストを読める一方、利用者が選ぶのはライブラリAPIではなく、認証サーバーの機能・運用責任・プロキシ連携を含むデプロイ可能な基盤だからである。比較軸は、B2Bマルチテナント適合性、認証プロトコル、下流連携、管理性、セキュリティ検証、導入・運用負荷、ライセンスと採用シグナルに置いた。
+
+## 2. 比較対象と選定理由
+
+| 製品 | 何ができるか | 採用状況 | ライセンス | うちとの決定的な違い | なぜ選んだか |
+|---|---|---|---|---|---|
+| Keycloak | OIDC/OAuth/SAML、IdP broker、WebAuthn、MFA、LDAP/AD、管理コンソール、Organizations、SCIM（現行 docs では preview） | ★35.9k / 最新リリース 26.6.3（2026-06-04） | Apache-2.0 | 機能・エコシステム・運用実績が大きい。設定と管理UI中心 | 自己ホストIAMの標準的な代替候補で、Java製でもある |
+| authentik | SAML、OAuth2/OIDC、LDAP、RADIUS、proxy provider、SCIMなどをUI/flowで構成 | ★21.7k / 最新リリース 2026.5.0（2026-05-22） | 本調査で正確なライセンス識別子を確定できず | UI/flow中心で、ForwardAuthに近いプロキシ統合と広いprovider群を持つ | self-hosted SSO と認証プロキシの実利用比較に適する |
+| ZITADEL | OIDC/OAuth/SAML、MFA/Passkeys、SCIM、監査イベント、Organizations/Projects、API/SDK | ★14.6k / 最新リリース情報は参照ページで確定できず | AGPL-3.0（特定ディレクトリに例外あり） | B2Bマルチテナントを中心に設計し、イベント駆動・API-first | 本repoと同じくB2B SaaSを正面から扱うOSS |
+| Ory Kratos | headlessなidentity管理、Passkeys、social login、OIDC、magic link、MFA、TOTP、SAML | ★13.8k / 最新リリース 26.2.0（2026-03-20） | Apache-2.0 | 認証・identityに特化した部品で、Ory Networkや他のOry製品との組み合わせが前提 | 「自作認証をやめる」場合のAPI-firstな部品候補 |
+
+この地図は、単一の勝者がいる市場ではなく、巨大な統合型（Keycloak）、UI/プロキシ寄り（authentik）、B2B SaaS寄り（ZITADEL）、headless部品型（Ory）に分かれている。volta の差は機能数ではなく、下流アプリをヘッダ契約へ縮約し、認証フロー変更をPRでレビューする点にある。ただし star 数は採用そのものではなく、voltaの本番採用を裏付ける数字はまだ分からない。
+
+## 4. 機能比較
+
+| 機能 | 重み | volta-auth-proxy | Keycloak | authentik | ZITADEL | Ory Kratos |
+|---|---|---:|---:|---:|---:|---:|
+| OIDC/OAuthログイン | ◎ | ○ | ○ | ○ | ○ | ○ |
+| SAML IdP/SP連携 | ◎ | ○ | ○ | ○ | ○ | △ |
+| TOTP MFA / Passkey | ◎ | ○ | ○ | ○ | ○ | ○ |
+| SaaSテナント・メンバー・招待 | ◎ | ○ | △ | △ | ○ | △ |
+| 下流アプリへのForwardAuth/identity header | ◎ | ○ | △ | ○ | △ | △ |
+| SCIM provisioning | ○ | ○ | △（preview） | ○ | ○ | △ |
+| M2M client credentials | ○ | ○ | ○ | ○ | ○ | △ |
+| 監査ログと外部sink | ○ | ○ | ○ | △ | ○ | △ |
+| Auth flowをPRでレビュー・git revert | ◎ | ○ | × | × | △ | △ |
+| 定義時のstate machine検証と図生成 | ○ | ○ | × | × | × | × |
+| GDPR export/erasureの組み込み | ○ | ○ | △ | △ | △ | △ |
+| 管理UI・広いproviderエコシステム | △ | △ | ○ | ○ | ○ | △ |
+
+voltaの痛い×は、管理UIやproviderエコシステムではなく、認証基盤としての採用証拠と運用部品が不足していることだ。表の○のうち OIDC、SAML、MFA、Passkey、SCIM はすでに市場標準であり、単独の差別化にはならない。一方、ForwardAuthで下流アプリをヘッダ契約にできることと、フローをコード・テスト・レビューに載せることは、この比較単位で効く◎である。
+
+## 4.5 コード・実装の比較
+
+| 観点 | volta-auth-proxy | Keycloak | authentik | ZITADEL | Ory Kratos | 出典 |
+|---|---:|---:|---:|---:|---:|---|
+| 実装形態 | Java/Javalin単一アプリ、tramli flow | Java中心の大規模サーバー | Python/Go/Rust/TypeScript等の複合構成 | Goの大規模サーバー | Goのheadlessサーバー | 各公開リポジトリの構成 |
+| 自repoのJava本体 | 104 files / 16,872 LOC | — | — | — | — | `find src/main/java ... | wc`, `wc -l` |
+| 自repoのテスト | 42 files / 2,938 LOC、`mvn -q test`成功 | — | — | — | — | 調査時実行結果 |
+| Maven依存宣言 | 22 | — | — | — | — | `pom.xml` |
+| ライセンス | MIT | Apache-2.0 | 不明 | AGPL-3.0 | Apache-2.0 | 各 LICENSE / GitHub repository |
+| 公開API数・配布サイズ | 本調査では数えない | 本調査では比較不能 | 本調査では比較不能 | 本調査では比較不能 | 本調査では比較不能 | サーバー製品のためライブラリAPI比較は不適切 |
+
+競合4製品は「組み込みライブラリ」として配布APIを数える対象ではなく、サーバー製品または複数サービスの組み合わせであるため、公開API数・配布サイズを同じ定義で比較できなかった。公開コードのディレクトリ構成とREADMEは確認したが、各製品をローカルビルド・実行まではしていない。そのためこの行については断定しない。volta側はコードを読み、テストを実行したので、実装面の確信度は自repoに限って高い。
+
+## 5.5 調査者の見立て
+
+本当の勝負所は、機能数ではなく「認証の変更をコードレビュー可能な差分にしつつ、下流アプリをヘッダ契約に固定できるか」だと読める。これは Keycloak/Authentik の管理UIを置き換える話ではなく、SaaSチームの変更管理とアプリ実装を一体で軽くする話である。
+
+数字に出ていない懸念は、認証は失敗時の責任が重く、star 数の小さい新しい基盤を選ぶには脅威モデル、第三者評価、アップグレード手順、障害時の復旧実績が必要なことだ。READMEとテストは厚いが、本番採用・SLA・外部監査は本調査では分からない。
+
+私なら、次の四半期は新しい認証方式を増やさず、ForwardAuth契約を固定したリファレンス構成、負荷・障害・鍵ローテーションの検証、脅威モデルを公開し、「軽いから選ぶ」を「証拠があるから選ぶ」に変える。
+
+この見立てが外れるのは、対象顧客が実は独自フローではなく、管理UI・LDAP・多数の既製統合を最優先する場合、または Keycloak/Authentik がコード管理型の同等体験を提供し始める場合である。その場合、voltaの差は薄まり、既製品を使う方が合理的になる。
+
+## 6. 提案（優先順）
+
+| 順 | 提案 | 分類 | 根拠 | 最小の一手 | 効きそうな指標 |
+|---:|---|---|---|---|---|
+| 1 | 本番導入パッケージを作る（Docker/Compose、鍵ローテーション、バックアップ・復旧、upgrade/rollback、health check） | 伸ばす | 機能差より採用リスクが最大の弱点 | 新規導入を1本の検証可能な手順にし、失敗系をCIで実行 | 初回導入時間、復旧時間、upgrade成功率 |
+| 2 | ForwardAuthのヘッダ契約と信頼境界を正式仕様化する | 伸ばす | 下流アプリを簡単にする価値が中心 | `X-Volta-*` の署名/上書き防止、proxy trust、401/302契約を仕様書と統合テストにする | 下流アプリ側の認証コード行数、誤設定テスト数 |
+| 3 | 独立したセキュリティ証拠を増やす | 埋める | SAML防御テストは強みだが、採用判断に必要な外部検証・脅威モデルは未確認 | STRIDE相当の脅威モデル、鍵・cookie・tenant境界の公開テストマトリクスを追加 | 未解決高リスク数、境界テスト網羅率 |
+| 4 | tenant-awareの運用機能を一貫させる | 埋める | ZITADEL等はテナント管理・監査・APIを市場の主軸にしている | tenant単位の監査検索、IdP設定、quota/disable、exportを同じAPI/権限モデルへ寄せる | tenant onboarding時間、管理操作のAPI化率 |
+| 5 | 管理UIでKeycloak/Authentikを全面追随する | やらない | 既製品のエコシステムとUIの再発明で、コード管理型という差別化を薄める | UI追加前に「コードで管理できないと困る要件」があるかを確認する | 対応しないUI機能の件数ではなく、導入失敗理由 |
+
+## 7. 選択の分岐
+
+```mermaid
+flowchart TD
+  A[要件] --> B{管理UI・LDAP・広い統合が最優先?}
+  B -->|はい| C[Keycloak または authentik を選ぶ]
+  B -->|いいえ| D{B2B組織モデル・API・監査の完成度が最優先?}
+  D -->|はい| E[ZITADELを先に評価する]
+  D -->|いいえ| F{headless identity部品を組み合わせる?}
+  F -->|はい| G[Ory Kratosを評価する]
+  F -->|いいえ| H{ForwardAuthとPR管理型flowが重要?}
+  H -->|はい| I[volta-auth-proxyを評価する]
+  H -->|いいえ| J[要件に最も近い既製品を選ぶ]
+```
+
+この分岐では、voltaを選ばない条件を明示した。既製の管理面・統合数・運用実績が優先なら、voltaの機能実装量だけで逆転する理由はない。voltaは、下流アプリを認証から切り離し、フロー変更をコードレビューとテストに置きたいチームに限定して評価するのが妥当である。
+
+## 8. 出典
+
+| URL | 参照日 | 何の根拠に使ったか |
+|---|---|---|
+| [volta-auth-proxy README](https://github.com/opaopa6969/volta-auth-proxy/blob/7e6373473879aad813767a102ab908a2671d51df/README.md) | 2026-07-31 | repoの価値、ForwardAuth、対応機能、Auth as Code、tramli |
+| [volta architecture](https://github.com/opaopa6969/volta-auth-proxy/blob/7e6373473879aad813767a102ab908a2671d51df/docs/architecture.md) | 2026-07-31 | 実装構成、2層state machine、SAML防御、下流連携 |
+| [volta pom.xml](https://github.com/opaopa6969/volta-auth-proxy/blob/7e6373473879aad813767a102ab908a2671d51df/pom.xml) | 2026-07-31 | Java 21、依存宣言、tramli/Javalin等 |
+| [volta GitHub repository](https://github.com/opaopa6969/volta-auth-proxy) | 2026-07-31 | 公開リポジトリの存在。本repoのstar数は取得できず、図示しなかった |
+| [Keycloak GitHub](https://github.com/keycloak/keycloak) | 2026-07-31 | star 35.9k、Apache-2.0、Java中心の構成、公開コード規模のシグナル |
+| [Keycloak Server Administration Guide](https://www.keycloak.org/docs/latest/server_admin/) | 2026-07-31 | OIDC/SAML/WebAuthn/MFA、Organizations、SCIM preview、管理UI |
+| [authentik GitHub](https://github.com/goauthentik/authentik) | 2026-07-31 | star 21.7k、SSO/provider、self-host方式、複合コード構成 |
+| [authentik providers](https://docs.goauthentik.io/providers/) | 2026-07-31 | OIDC/OAuth、LDAP、SAML、proxy、SCIM provider |
+| [authentik OAuth2 provider](https://docs.goauthentik.io/add-secure-apps/providers/oauth2/) | 2026-07-31 | OAuth2/OIDC flow、PKCE、client credentials等 |
+| [ZITADEL GitHub](https://github.com/zitadel/zitadel) | 2026-07-31 | star 14.6k、AGPL-3.0、Go構成、公開コード規模のシグナル |
+| [ZITADEL Organizations](https://zitadel.com/docs/guides/manage/console/organizations-overview) | 2026-07-31 | B2B multi-tenancy、組織分離・委譲 |
+| [ZITADEL API reference](https://zitadel.com/docs/apis/introduction) | 2026-07-31 | API-first、OIDC/OAuth/SAML、SDK、Actions |
+| [Ory Kratos GitHub](https://github.com/ory/kratos) | 2026-07-31 | star 13.8k、Apache-2.0、headless Go構成 |
+| [Ory Kratos releases](https://github.com/ory/kratos/releases) | 2026-07-31 | 最新リリースとSAML/Passkey/MFA等の更新内容 |
+| [Ory Kratos product page](https://www.ory.com/kratos) | 2026-07-31 | self-hosted/OSS/Enterprise/managedの提供形態 |
+
+競合の star とリリース日は各GitHubページで 2026-07-31 に確認した値である。authentikのライセンス識別子とZITADELの最新リリース日は本調査では確定できなかったため、front matter と本文で不明と明記した。公開コードをローカルでビルド・実行したのは自repoのみである。

--- a/docs/mcp/DESIGN.md
+++ b/docs/mcp/DESIGN.md
@@ -1,0 +1,112 @@
+# MCP 設計書: volta-auth-proxy (namespace: `auth`)
+
+> Phase 1 survey.json (decision=wrap) に基づく。割当表 #14: namespace=`auth`, port=9211。
+
+## 1. namespace と種別
+
+- **namespace**: `auth`（予約語 `catalog`/`probe`/`skill` と衝突しない）
+- **種別**: `wrap` — 既存 Java REST API（Javalin, port 7070）を薄く包む Node.js MCP サーバ
+- **ホスト**: 192.168.1.8（既存の `volta-auth-proxy` と同じ WSL ホスト）
+- **MCP ポート**: 9211（割当表指定、machine_ports で空き確認済み）
+- **min_role**: MEMBER（認証系の操作はメンバー以上に見せる）
+
+## 2. 認証コンテキストの設計
+
+既存の REST API は JWT（`Authorization: Bearer`）またはセッション cookie で認証する。
+MCP tool 経由の呼び出しではエージェントがブラウザ cookie を持たないため、**M2M トークン（`issue_m2m_token` で `client_credentials` グラント）→ 得られた JWT を以降の tool 呼び出しに渡す** 2 段階を基本とする。
+
+- `auth__issue_m2m_token` は `{client_id, client_secret, scope?, audience?}` を受け取り、`{access_token, token_type, expires_in, scope}` を返す（POST /oauth/token へのラップ）。
+- 以降の tool 呼び出しでは `jwt` パラメータ（string）で得られた access_token を渡す。MCP サーバは `Authorization: Bearer <jwt>` として Java API に転送する。
+- 破壊的操作（鍵ローテーション、アカウント削除、メンバー削除等）は `confirm: boolean=false` を持ち、false なら dry-run（対象と予定を返す）。
+
+## 3. tools 表
+
+| name | 目的 | 入力 schema（要点） | 出力の形 | 副作用 | dry-run | job 型 | 所要時間 | min_role |
+|------|------|---------------------|----------|--------|---------|--------|----------|----------|
+| `verify_session` | セッションを検証して X-Volta-* ヘッダを返す | `{cookie: string}` | `{userId, tenantId, roles, jwt, appId} \| 401` | read | no | no | <1s | VIEWER |
+| `refresh_token` | JWT をリフレッシュする | `{jwt: string}` | `{token: string, expires_in: number}` | write | no | no | <1s | MEMBER |
+| `issue_m2m_token` | M2M クライアント認証でトークンを発行する | `{client_id: string, client_secret: string, scope?: string, audience?: string}` | `{access_token, token_type, expires_in, scope}` | write | no | no | <1s | MEMBER |
+| `get_current_user` | 現在のユーザー情報を取得する | `{jwt: string}` | `{id, email, displayName, tenantId, roles}` | read | no | no | <1s | MEMBER |
+| `list_user_tenants` | ユーザーが所属するテナント一覧を取得する | `{jwt: string}` | `{data: [{id, name, slug, role, isLast}]}` | read | no | no | <1s | MEMBER |
+| `get_tenant` | テナント情報を取得する | `{jwt: string, tenantId: string}` | tenantDetail | read | no | no | <1s | MEMBER |
+| `list_tenant_members` | テナントメンバー一覧を取得する | `{jwt: string, tenantId: string, offset?: number, limit?: number}` | paginated members | read | no | no | <1s | MEMBER |
+| `change_member_role` | メンバーロールを変更する | `{jwt: string, tenantId: string, memberId: string, role: string, confirm?: boolean}` | `{ok: true} \| dry-run` | write | yes | no | <1s | ADMIN |
+| `remove_member` | メンバーを削除する | `{jwt: string, tenantId: string, memberId: string, confirm?: boolean}` | `{ok: true} \| dry-run` | destructive | yes | no | <1s | ADMIN |
+| `create_invitation` | テナントに招待を作成する | `{jwt: string, tenantId: string, email?: string, role?: string, max_uses?: number, expires_in_hours?: number}` | `{id, code, link, expiresAt}` | write | no | no | <1s | MEMBER |
+| `list_invitations` | テナントの招待一覧を取得する | `{jwt: string, tenantId: string, status?: string}` | paginated invitations | read | no | no | <1s | MEMBER |
+| `cancel_invitation` | 招待をキャンセルする | `{jwt: string, tenantId: string, invitationId: string, confirm?: boolean}` | `{ok: true} \| dry-run` | write | yes | no | <1s | MEMBER |
+| `list_sessions` | セッション一覧を取得する | `{jwt: string}` | `{items: [{id, tenantId, ip, lastActiveAt, device, browser, os}]}` | read | no | no | <1s | MEMBER |
+| `revoke_session` | セッションを失効する | `{jwt: string, sessionId: string, confirm?: boolean}` | `{ok: true} \| dry-run` | write | yes | no | <1s | MEMBER |
+| `revoke_all_sessions` | 全セッションを失効する | `{jwt: string, confirm?: boolean}` | `{ok: true} \| dry-run` | destructive | yes | no | <1s | MEMBER |
+| `mfa_setup` | MFA (TOTP) セットアップを開始する | `{jwt: string, userId: string}` | `{secret, otpauth_url}` | write | no | no | <1s | MEMBER |
+| `mfa_verify` | MFA (TOTP) を検証・有効化する | `{jwt: string, userId: string, code: string}` | `{ok, enabled}` | write | no | no | <1s | MEMBER |
+| `get_mfa_status` | MFA ステータスを取得する | `{jwt: string}` | `{totp: {enabled}, recovery_codes_remaining}` | read | no | no | <1s | MEMBER |
+| `rotate_signing_key` | 署名鍵をローテーションする | `{jwt: string, confirm?: boolean}` | `{ok, kid} \| dry-run` | destructive | yes | no | <1s | OWNER |
+| `list_audit_logs` | 監査ログを取得する | `{jwt: string, tenantId?: string, from?: string, to?: string, event?: string, offset?: number, limit?: number}` | paginated logs | read | no | no | <1s | ADMIN |
+| `list_flow_definitions` | 認証フロー定義一覧を取得する | `{}` | `{flows: [{name, mermaid, stateDiagram}]}` | read | no | no | <1s | VIEWER |
+| `list_flows` | 認証フロー実行一覧を取得する | `{jwt: string, tenant_id?: string, flow_type?: string, since?: string, limit?: number}` | `{flows: [...]}` | read | no | no | <1s | ADMIN |
+| `get_flow_transitions` | フロー遷移履歴を取得する | `{jwt: string, flowId: string}` | `{flowId, transitions: [...]}` | read | no | no | <1s | ADMIN |
+| `export_user_data` | GDPR データエクスポート | `{jwt: string}` | JSON (user, memberships, sessions, devices) | read | no | no | <1s | MEMBER |
+| `request_account_deletion` | GDPR 削除要求 | `{jwt: string, confirm?: boolean}` | `{status: scheduled, delete_at} \| dry-run` | destructive | yes | no | <1s | MEMBER |
+
+## 4. resources 表
+
+| uri | 内容 | mime |
+|-----|------|------|
+| `auth://spec` | 能力の機械可読仕様（tools/list から生成 + compositions/depends_on） | application/json |
+| `auth://guide` | 使い方ガイド（M2M トークン→tool 呼び出しの流れ、confirm の使い方） | text/markdown |
+| `auth://jwks` | JWKS 公開鍵（`/.well-known/jwks.json` のプロキシ） | application/json |
+| `auth://flows` | 認証フロー図（mermaid + stateDiagram、`/viz/flows` のプロキシ） | application/json |
+
+## 5. prompts / skills
+
+| name | 用途 | locality |
+|------|------|----------|
+| `operate-auth-proxy` | volta-auth-proxy の運用手順（M2M トークン発行→各種操作→confirm） | service（`docs/skills/operate-auth-proxy/SKILL.md` + resource `skill://operate-auth-proxy`） |
+
+## 6. 組み合わせ例
+
+1. `auth__issue_m2m_token → auth__get_current_user → auth__list_user_tenants` — M2M トークンを発行し、ユーザー情報とテナント一覧を取得する基本フロー
+2. `auth__list_audit_logs → index__agent_fork` — 監査ログから不審なアクティビティを検知したら調査エージェントを起動
+3. `auth__list_flow_definitions → design__get_component_snippet` — 認証フローの状態遷移図を UI コンポーネントで可視化
+4. `auth__issue_m2m_token → volta__svc_deploy` — デプロイ用 M2M トークンを発行してサービスデプロイを自動化
+
+## 7. 依存と協調
+
+| 相手 repo | 方向 | 能力 | 合意したいこと |
+|-----------|------|------|----------------|
+| tramli | depends_on | state machine engine | フロー定義 API の形式確定（暫定: `/viz/flows` の JSON 形式をそのまま使用） |
+| volta-auth-console | provides_to | Internal API (/api/v1/*) | 管理UI と MCP tool の役割分担（暫定: MCP は API 経由の自動化用途、UI は人間向け） |
+| volta-gateway (Rust) | depends_on | 後継認証サーバ | 後継への MCP 移行タイミング（暫定: 並行稼働、retired 確定時に移行） |
+| auth-test/volta-gateway (vgw-mcp) | coordinate | `vgw` namespace は後継 volta-auth-server/Rust 向け | `vgw__audit_search` / `vgw__user_search` / `vgw__tenant_list` は後継 (Rust) の監査ログ・ユーザー・テナント操作。`auth__list_audit_logs` 等は旧版 (Java) の同等 API。対象システムが違うため重複ではないが、エージェントは active な後継 (vgw) を優先し、旧版 (auth) は後継に未移行の機能の補完として使うこと（暫定） |
+
+issue-hub に `mcp-coordination` ラベルで登録する。
+
+## 8. 非対応にした候補
+
+Phase 1 survey からの差分:
+- **Passkey 登録系** (`/api/v1/users/{userId}/passkeys/*`) — WebAuthn のチャレンジレスポンスフローは MCP tool 向きでない（ブラウザの WebAuthn API が必要）。除外。
+- **Stripe Billing 系** (`/api/v1/tenants/{tid}/billing/*`) — 外部課金 API を扱う。破壊的操作かつ課金リスクが高く、M2M 自動化用途に合わない。除外。
+- **SCIM 系** (`/scim/v2/*`) — 外部 IdP 同期用。MCP tool としての需要が低い。除外。
+- **管理画面 HTML ルート** (`/admin/*`, `/settings/*`) — HTML ページ配信。MCP tool でなくてよい。除外。
+
+## 9. 参加方法
+
+- **manifest**: `volta.service.json` を root に配置
+- **id**: `volta-auth-proxy`（catalog 既存 id。MCP 項を追加する形）
+- **hostname**: `auth-proxy.unlaxer.org`（新規サブドメイン、MCP/API 用）
+- **port**: 9211（MCP サーバ）
+- **host**: 192.168.1.8（WSL）
+- **runtime**: systemd user unit
+- **auth**: minRole:MEMBER
+- **health_check**: /healthz
+
+## 10. テスト方針
+
+- e2e: MCP クライアント（`@modelcontextprotocol/sdk` の `Client` + `StreamableHTTPClientTransport`）で
+  1. `/healthz` 200 確認
+  2. `tools/list` で全 tool が見える
+  3. `issue_m2m_token` の dry-run（client_id/secret 無しで 400 を期待、schema validation 確認）
+  4. `auth://spec` resource の取得
+  5. `auth://guide` resource の取得
+  6. confirm required tool の dry-run（confirm=false → dry-run message）

--- a/docs/mcp/STATUS.md
+++ b/docs/mcp/STATUS.md
@@ -1,6 +1,6 @@
 # MCP 化 Phase 2 STATUS — volta-auth-proxy
 
-> 更新: 2026-08-22
+> 更新: 2026-08-22 (最終確認完了)
 
 ## 進捗
 
@@ -20,8 +20,8 @@
 | Deploy | gateway_routes_diff | done (1 件: auth-mcp.unlaxer.org) |
 | Deploy | gateway_routes_apply confirm:true | done (SIGHUP 済み) |
 | Deploy | prod で MCP サーバ起動 | done (systemctl --user enable --now) |
-| Deploy | https://auth-mcp.unlaxer.org/healthz 200 | pending (確認中) |
-| Deploy | catalog__backend_status ready | pending (確認中) |
+| Deploy | https://auth-mcp.unlaxer.org/healthz 200 | done (200, {"ok":true,"name":"auth-mcp","version":"0.1.0"}) |
+| Deploy | catalog__backend_status ready | done (status=ready, tools=25, server=auth-mcp v0.1.0) |
 
 ## dry-run 記録
 

--- a/docs/mcp/STATUS.md
+++ b/docs/mcp/STATUS.md
@@ -1,0 +1,60 @@
+# MCP 化 Phase 2 STATUS — volta-auth-proxy
+
+> 更新: 2026-08-22
+
+## 進捗
+
+| Phase | 項目 | 状態 |
+|-------|------|------|
+| Design | DESIGN.md 作成 | done |
+| Design | vgw との役割分担整理 | done |
+| Coord | issue-hub に協調 issue 登録 | done (#260, #261, #262) |
+| Impl | MCP サーバ実装 (mcp/server.mjs) | done |
+| Impl | e2e テスト (mcp/test/e2e.mjs) | done (ALL PASSED) |
+| Impl | volta.service.json | done |
+| Impl | deploy/volta-auth-proxy-mcp.service | done |
+| Impl | run.sh | done |
+| Impl | skill docs/skills/operate-auth-proxy/SKILL.md | done |
+| Deploy | volta__svc_add dry-run | done (差分確認済み) |
+| Deploy | volta__svc_add confirm:true | done (volta-auth-proxy-mcp 登録) |
+| Deploy | gateway_routes_diff | done (1 件: auth-mcp.unlaxer.org) |
+| Deploy | gateway_routes_apply confirm:true | done (SIGHUP 済み) |
+| Deploy | prod で MCP サーバ起動 | done (systemctl --user enable --now) |
+| Deploy | https://auth-mcp.unlaxer.org/healthz 200 | pending (確認中) |
+| Deploy | catalog__backend_status ready | pending (確認中) |
+
+## dry-run 記録
+
+### svc_add dry-run
+- 新規サービス `volta-auth-proxy-mcp`
+- port 9211, host 192.168.1.8, namespace=auth
+- 差分: services.json に新規エントリ追加（MCP 項あり）
+
+### gateway_routes_diff
+- 変更: `[新規] auth-mcp.unlaxer.org -> http://192.168.1.8:9211` (1 件)
+- 温存: 2 件 (adoyose-admin, mahjong-mcp — 手動設定の残置)
+- 自分の 1 件のみのため confirm して適用
+
+### gateway_routes_apply (confirm:true)
+- バックアップ: /home/opa/volta-gateway/volta-gateway.yaml.bak-generated-20260822-024548
+- SIGHUP 済み（瞬断なし）
+
+## issue-hub
+
+| # | title | target | 状態 |
+|---|-------|--------|------|
+| 260 | auth → tramli: フロー定義 API 形式の確認 | tramli | open (暫定仕様で進行) |
+| 261 | auth → volta-auth-console: 管理UI と MCP tool の役割分担 | volta-auth-console | open (暫定仕様で進行) |
+| 262 | auth → vgw: 旧版(Java)と後継(Rust)の役割分担 | auth-test/volta-gateway | open (暫定仕様で進行) |
+
+## 未決事項
+
+1. **retired 確定判定**: volta-auth-proxy (Java) は catalog で operational_status=retired。後継 volta-auth-server (Rust) が active。本 MCP ラップは後継に未移行の機能の補完として位置づけ。retired 確定時に auth namespace を disable し vgw に完全移行するタイミングは持ち主が判断。
+2. **認証コンテキスト**: M2M トークン発行→JWT 渡しの 2 段階を採用。エージェントがユーザー JWT を外部から注入する形は未対応（暫定）。
+3. **tramli フロー定義形式**: /viz/flows の JSON 形式を暫定使用。tramli 側で形式確定時に #260 で合わせる。
+
+## 割当表との整合
+
+- 割当表 #14: namespace=`auth`, port=9211
+- machine_ports で 9211 が空きなことを確認済み
+- 既存サービス `volta-auth-proxy` (port 7070) とは別 id `volta-auth-proxy-mcp` で新規登録

--- a/docs/mcp/SURVEY.md
+++ b/docs/mcp/SURVEY.md
@@ -1,0 +1,92 @@
+# MCP 化調査: volta-auth-proxy
+
+## 概要
+
+volta-auth-proxy はマルチテナント認証ゲートウェイ（Java 21 / Javalin 6.7）。OIDC（Google/GitHub/Microsoft/Apple）、SAML SSO、Passkey（WebAuthn）、MFA（TOTP）、JWT 発行、セッション管理、テナント・招待・RBAC、SCIM、Stripe Billing を単一プロセスで提供する。Traefik ForwardAuth パターンで下流アプリに `X-Volta-*` ヘッダを注入する。
+
+tramli（制約付きステートマシンエンジン）で全認証フローを駆動し、tramli-plugins で監査/lint/オブザーバビリティを横断適用。
+
+**catalog 上の状態**: `operational_status: "retired"`。後継の `volta-auth-server`（Rust 製 `volta-gateway` に内蔵）が `active` で稼働中。
+
+## 判定と理由
+
+**判定: `wrap`**（優先度は低い）
+
+既に豊富な REST API を持つ常駐サーバであり、MCP 化は既存エンドポイントを薄く包むだけで済む。ただし:
+
+1. catalog で **retired** 扱い。後継の Rust 版認証サーバが active で稼働中。
+2. MCP ラップを付けても、本番トラフィックがこの Java 版に来ていなければ価値が薄い。
+3. 後継 `volta-auth-server` 側に MCP を付ける方が、active な方への投資として妥当。
+
+機能の大部分が後継に移行済みであれば `skip` に倒すべき。退役が確定しているか、まだ使う予定があるかが判断の分かれ目。
+
+## 公開候補
+
+| kind | name | io | 副作用 | 長時間 | 対象 |
+|------|------|-----|--------|--------|------|
+| tool | `verify_session` | cookie/header → {userId, tenantId, roles, jwt} | read | no | GET /auth/verify |
+| tool | `refresh_token` | session cookie → {token: jwt} | write | no | POST /auth/refresh |
+| tool | `issue_m2m_token` | {client_id, client_secret, scope?} → {access_token, ...} | write | no | POST /oauth/token |
+| tool | `get_current_user` | jwt → {id, email, displayName, tenantId, roles} | read | no | GET /api/v1/users/me |
+| tool | `list_user_tenants` | jwt → [{id, name, slug, role}] | read | no | GET /api/v1/users/me/tenants |
+| tool | `get_tenant` | {tenantId} + jwt → tenantDetail | read | no | GET /api/v1/tenants/{tid} |
+| tool | `list_tenant_members` | {tenantId} + jwt → paginated | read | no | GET /api/v1/tenants/{tid}/members |
+| tool | `create_invitation` | {tenantId, email?, role?, ...} + jwt → {code, link} | write | no | POST /api/v1/tenants/{tid}/invitations |
+| tool | `list_invitations` | {tenantId, status?} + jwt → paginated | read | no | GET /api/v1/tenants/{tid}/invitations |
+| tool | `cancel_invitation` | {tenantId, invitationId} + jwt → {ok} | write | no | DELETE /api/v1/tenants/{tid}/invitations/{iid} |
+| tool | `change_member_role` | {tenantId, memberId, role} + jwt → {ok} | write | no | PATCH /api/v1/tenants/{tid}/members/{mid} |
+| tool | `remove_member` | {tenantId, memberId} + jwt → {ok} | write | no | DELETE /api/v1/tenants/{tid}/members/{mid} |
+| tool | `list_sessions` | jwt → [{id, ip, device, ...}] | read | no | GET /api/v1/users/me/sessions |
+| tool | `revoke_session` | {sessionId} + jwt → {ok} | write | no | DELETE /api/v1/users/me/sessions/{id} |
+| tool | `revoke_all_sessions` | jwt → {ok} | write | no | DELETE /api/me/sessions |
+| tool | `mfa_setup` | {userId} + jwt → {secret, otpauth_url} | write | no | POST /api/v1/users/{uid}/mfa/totp/setup |
+| tool | `mfa_verify` | {userId, code} + jwt → {ok, enabled} | write | no | POST /api/v1/users/{uid}/mfa/totp/verify |
+| tool | `get_mfa_status` | jwt → {totp, recovery_codes_remaining} | read | no | GET /api/v1/users/me/mfa |
+| tool | `rotate_signing_key` | jwt(OWNER) → {ok, kid} | write | no | POST /api/v1/admin/keys/rotate |
+| tool | `list_audit_logs` | {tenantId?, from?, to?, event?} + jwt(ADMIN+) → paginated | read | no | GET /api/v1/admin/audit |
+| tool | `list_flow_definitions` | → {flows: [{name, mermaid, stateDiagram}]} | read | no | GET /viz/flows |
+| tool | `list_flows` | {tenant_id?, flow_type?, since?} + jwt(ADMIN) → {flows} | read | no | GET /api/v1/admin/flows |
+| tool | `get_flow_transitions` | {flowId} + jwt(ADMIN) → {transitions} | read | no | GET /api/v1/admin/flows/{flowId}/transitions |
+| tool | `export_user_data` | jwt → JSON (GDPR) | read | no | POST /api/v1/users/me/data-export |
+| tool | `request_account_deletion` | jwt → {status, delete_at} | write | no | DELETE /api/v1/users/me |
+| resource | `spec` | — | — | — | auth://spec（能力の機械可読仕様） |
+| resource | `guide` | — | — | — | auth://guide（使い方） |
+| resource | `jwks` | — | — | — | auth://jwks（JWKS 公開鍵） |
+| resource | `flow_definitions` | — | — | — | auth://flows（認証フロー図） |
+| skill | `operate-auth-proxy` | — | — | — | repo locality（運用手順） |
+
+## 組み合わせ例
+
+1. `auth__verify_session → volta__svc_health` — セッション検証後に認証関連サービスの健全性を確認
+2. `auth__list_audit_logs → index__agent_fork` — 監査ログから不審なアクティビティを検知したら調査エージェントを起動
+3. `auth__list_flow_definitions → design__get_component_snippet` — 認証フローの状態遷移図を UI コンポーネントで可視化
+4. `auth__issue_m2m_token → volta__svc_deploy` — デプロイ用 M2M トークンを発行してサービスデプロイを自動化
+
+## 依存と協調
+
+| 相手 repo | 方向 | 能力 | 現存 | 備考 |
+|-----------|------|------|------|------|
+| tramli | depends_on | state machine engine | yes | pom.xml 依存。認証フロー定義・実行の中核 |
+| tramli-plugins | depends_on | audit/lint/observability plugins | yes | pom.xml 依存。全フローに横断的関心事を適用 |
+| volta-gateway | depends_on | 認証サーバ（Rust 版後継） | yes | catalog で active。本リポジトリは retired |
+| volta-auth-console | provides_to | Internal API (/api/v1/*) | yes | React 製管理 UI が本プロキシの API を消費 |
+| nanori-site | provides_to | 認証（管理コンソールが volta-auth 認証を使用） | yes | catalog に記載。nanori が認証を委譲している可能性 |
+
+## ライブラリのサーバ化
+
+該当しない。既に常駐サーバ（Javalin, port 7070, /healthz あり）。
+
+## リスク
+
+- **retired 状態**: catalog で退役扱い。後継 `volta-auth-server` (Rust) が active。MCP ラップを付けても本番運用に乗らない可能性
+- **秘密情報**: `JWT_KEY_ENCRYPTION_SECRET`, `VOLTA_SERVICE_TOKEN`,各 IdP client secret, Stripe secret key 等の環境変数を扱う。MCP 経由で漏洩しないよう注意
+- **破壊的操作**: アカウント削除(GDPR)、鍵ローテーション、メンバー削除、セッション失効等。confirm パラメータを必須にすべき
+- **外部 API 課金**: Stripe (billing), Google/Microsoft OIDC (API クォータ), Fraud Alert (FRAUD_ALERT_URL)
+- **認証コンテキスト**: MCP tool 経由の呼び出しで JWT/cookie をどう扱うかが課題。エージェントがブラウザセッション cookie を持つ形は不自然。M2M トークン発行→tool 呼び出しの 2 段階が現実的
+
+## 持ち主への質問
+
+1. retired 確定か? 後継 `volta-auth-server` (Rust) に機能が完全に移行済みなら、このリポジトリの MCP 化は `skip` にすべき
+2. もし MCP 化するなら、認証コンテキストをどう渡すか（M2M トークン発行→tool 呼び出しの 2 段階？ユーザー JWT を外部から注入？）
+3. `volta-auth-console` (React 管理 UI) との役割分担。MCP tool は管理 UI がやることを代替するのか、API 経由の自動化用途か
+4. 後継 `volta-auth-server` (Rust) 側に MCP を付ける方が適切ではないか（active な方に投資すべき）

--- a/docs/mcp/survey.json
+++ b/docs/mcp/survey.json
@@ -1,0 +1,336 @@
+{
+  "repo": "volta-auth-proxy",
+  "surveyed_at": "2026-08-22T00:00:00Z",
+  "kind": "service",
+  "summary": "マルチテナント認証ゲートウェイ（Java/Javalin）。OIDC/SAML/Passkey/MFA・JWT 発行・セッション・テナント・招待・RBAC・SCIM・Billing を 1 プロセスで提供。ForwardAuth パターンで下流 App に X-Volta-* ヘッダを注入する。catalog 上は retired（後継: volta-auth-server / Rust 製 volta-gateway が active）。",
+  "decision": "wrap",
+  "decision_reason": "既に豊富な REST API（/api/v1/*, /auth/*, /scim/v2/*, /oauth/token, /healthz, /.well-known/jwks.json）を持つ常駐サーバ。MCP 化は既存 API を薄く包む（wrap）だけで済む。ただし catalog で operational_status=retired であり、後継の volta-auth-server（Rust）が active になっているため、投資の優先度は低い。機能の大部分は後継に移行済みと見られ、MCP ラップを付ける価値があるかは後継の動向次第。退役確定なら skip に倒すべき。",
+  "existing": {
+    "http_api": true,
+    "cli": false,
+    "mcp": false,
+    "healthz": true,
+    "volta_manifest": false,
+    "hosted_url": null
+  },
+  "proposed_namespace": "auth",
+  "capabilities": [
+    {
+      "verb": "セッションを検証して X-Volta-* ヘッダを返す",
+      "kind": "tool",
+      "name": "verify_session",
+      "io": "cookie/header → {userId, tenantId, roles, jwt, appId} | 401",
+      "side_effect": "read",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/auth/AuthFlowHandler.java:verify (GET /auth/verify)"
+    },
+    {
+      "verb": "JWT をリフレッシュする",
+      "kind": "tool",
+      "name": "refresh_token",
+      "io": "session cookie → {token: jwt}",
+      "side_effect": "write",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/AuthRouter.java:204 (POST /auth/refresh)"
+    },
+    {
+      "verb": "M2M クライアント認証でトークンを発行する",
+      "kind": "tool",
+      "name": "issue_m2m_token",
+      "io": "{client_id, client_secret, scope?, audience?} → {access_token, token_type, expires_in, scope}",
+      "side_effect": "write",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/Main.java:418 (POST /oauth/token)"
+    },
+    {
+      "verb": "現在のユーザー情報を取得する",
+      "kind": "tool",
+      "name": "get_current_user",
+      "io": "jwt → {id, email, displayName, tenantId, roles}",
+      "side_effect": "read",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:283 (GET /api/v1/users/me)"
+    },
+    {
+      "verb": "ユーザーが所属するテナント一覧を取得する",
+      "kind": "tool",
+      "name": "list_user_tenants",
+      "io": "jwt → {data: [{id, name, slug, role, isLast}]}",
+      "side_effect": "read",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:375 (GET /api/v1/users/me/tenants)"
+    },
+    {
+      "verb": "テナント情報を取得する",
+      "kind": "tool",
+      "name": "get_tenant",
+      "io": "{tenantId} + jwt → tenantDetail",
+      "side_effect": "read",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:393 (GET /api/v1/tenants/{tenantId})"
+    },
+    {
+      "verb": "テナントメンバー一覧を取得する",
+      "kind": "tool",
+      "name": "list_tenant_members",
+      "io": "{tenantId} + jwt → paginated members",
+      "side_effect": "read",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:572 (GET /api/v1/tenants/{tenantId}/members)"
+    },
+    {
+      "verb": "テナントに招待を作成する",
+      "kind": "tool",
+      "name": "create_invitation",
+      "io": "{tenantId, email?, role?, max_uses?, expires_in_hours?} + jwt → {id, code, link, expiresAt}",
+      "side_effect": "write",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:617 (POST /api/v1/tenants/{tenantId}/invitations)"
+    },
+    {
+      "verb": "テナントの招待一覧を取得する",
+      "kind": "tool",
+      "name": "list_invitations",
+      "io": "{tenantId, status?} + jwt → paginated invitations",
+      "side_effect": "read",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:675 (GET /api/v1/tenants/{tenantId}/invitations)"
+    },
+    {
+      "verb": "招待をキャンセルする",
+      "kind": "tool",
+      "name": "cancel_invitation",
+      "io": "{tenantId, invitationId} + jwt → {ok: true}",
+      "side_effect": "write",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:685 (DELETE /api/v1/tenants/{tenantId}/invitations/{invitationId})"
+    },
+    {
+      "verb": "メンバーロールを変更する",
+      "kind": "tool",
+      "name": "change_member_role",
+      "io": "{tenantId, memberId, role} + jwt → {ok: true}",
+      "side_effect": "write",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:590 (PATCH /api/v1/tenants/{tenantId}/members/{memberId})"
+    },
+    {
+      "verb": "メンバーを削除する",
+      "kind": "tool",
+      "name": "remove_member",
+      "io": "{tenantId, memberId} + jwt → {ok: true}",
+      "side_effect": "write",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:699 (DELETE /api/v1/tenants/{tenantId}/members/{memberId})"
+    },
+    {
+      "verb": "セッション一覧を取得する",
+      "kind": "tool",
+      "name": "list_sessions",
+      "io": "jwt → {items: [{id, tenantId, ip, lastActiveAt, device, browser, os}]}",
+      "side_effect": "read",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:240 (GET /api/v1/users/me/sessions)"
+    },
+    {
+      "verb": "セッションを失効する",
+      "kind": "tool",
+      "name": "revoke_session",
+      "io": "{sessionId} + jwt → {ok: true}",
+      "side_effect": "write",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:227 (DELETE /api/v1/users/me/sessions/{id})"
+    },
+    {
+      "verb": "全セッションを失効する",
+      "kind": "tool",
+      "name": "revoke_all_sessions",
+      "io": "jwt → {ok: true}",
+      "side_effect": "write",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:250 (DELETE /api/me/sessions)"
+    },
+    {
+      "verb": "MFA (TOTP) セットアップを開始する",
+      "kind": "tool",
+      "name": "mfa_setup",
+      "io": "{userId} + jwt → {secret, otpauth_url}",
+      "side_effect": "write",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:443 (POST /api/v1/users/{userId}/mfa/totp/setup)"
+    },
+    {
+      "verb": "MFA (TOTP) を検証・有効化する",
+      "kind": "tool",
+      "name": "mfa_verify",
+      "io": "{userId, code} + jwt → {ok, enabled}",
+      "side_effect": "write",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:458 (POST /api/v1/users/{userId}/mfa/totp/verify)"
+    },
+    {
+      "verb": "MFA ステータスを取得する",
+      "kind": "tool",
+      "name": "get_mfa_status",
+      "io": "jwt → {totp: {enabled}, recovery_codes_remaining}",
+      "side_effect": "read",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:499 (GET /api/v1/users/me/mfa)"
+    },
+    {
+      "verb": "署名鍵をローテーションする",
+      "kind": "tool",
+      "name": "rotate_signing_key",
+      "io": "jwt(OWNER) → {ok, kid}",
+      "side_effect": "write",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:265 (POST /api/v1/admin/keys/rotate)"
+    },
+    {
+      "verb": "監査ログを取得する",
+      "kind": "tool",
+      "name": "list_audit_logs",
+      "io": "{tenantId?, from?, to?, event?, offset?, limit?} + jwt(ADMIN+) → paginated logs",
+      "side_effect": "read",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:1175 (GET /api/v1/admin/audit)"
+    },
+    {
+      "verb": "認証フロー定義一覧を取得する（tramli-viz）",
+      "kind": "tool",
+      "name": "list_flow_definitions",
+      "io": "→ {flows: [{name, mermaid, stateDiagram}]}",
+      "side_effect": "read",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/viz/VizRouter.java:134 (GET /viz/flows)"
+    },
+    {
+      "verb": "認証フロー実行一覧を取得する",
+      "kind": "tool",
+      "name": "list_flows",
+      "io": "{tenant_id?, flow_type?, since?, limit?} + jwt(ADMIN) → {flows: [...]}",
+      "side_effect": "read",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/viz/VizRouter.java:81 (GET /api/v1/admin/flows)"
+    },
+    {
+      "verb": "フロー遷移履歴を取得する",
+      "kind": "tool",
+      "name": "get_flow_transitions",
+      "io": "{flowId} + jwt(ADMIN) → {flowId, transitions: [...]}",
+      "side_effect": "read",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/viz/VizRouter.java:117 (GET /api/v1/admin/flows/{flowId}/transitions)"
+    },
+    {
+      "verb": "GDPR データエクスポート",
+      "kind": "tool",
+      "name": "export_user_data",
+      "io": "jwt → JSON attachment (user, memberships, sessions, devices)",
+      "side_effect": "read",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:295 (POST /api/v1/users/me/data-export)"
+    },
+    {
+      "verb": "GDPR 削除要求",
+      "kind": "tool",
+      "name": "request_account_deletion",
+      "io": "jwt → {status: scheduled, delete_at}",
+      "side_effect": "write",
+      "long_running": false,
+      "maps_to": "src/main/java/org/unlaxer/infra/volta/ApiRouter.java:302 (DELETE /api/v1/users/me)"
+    },
+    {
+      "verb": "能力の仕様",
+      "kind": "resource",
+      "name": "spec",
+      "uri": "auth://spec"
+    },
+    {
+      "verb": "使い方",
+      "kind": "resource",
+      "name": "guide",
+      "uri": "auth://guide"
+    },
+    {
+      "verb": "JWKS 公開鍵",
+      "kind": "resource",
+      "name": "jwks",
+      "uri": "auth://jwks"
+    },
+    {
+      "verb": "認証フロー図（mermaid + stateDiagram）",
+      "kind": "resource",
+      "name": "flow_definitions",
+      "uri": "auth://flows"
+    },
+    {
+      "verb": "volta-auth-proxy の運用手順",
+      "kind": "skill",
+      "name": "operate-auth-proxy",
+      "locality": "repo"
+    }
+  ],
+  "composition_examples": [
+    "auth__verify_session → (tenantId を取得) → volta__svc_health(auth 関連サービスの健全性確認)",
+    "auth__list_audit_logs → index__agent_fork (監査ログから不審なアクティビティを検知したら調査エージェントを起動)",
+    "auth__list_flow_definitions → design__get_component_snippet (認証フローの状態遷移図を UI コンポーネントで可視化)",
+    "auth__issue_m2m_token → volta__svc_deploy (デプロイ用 M2M トークンを発行してサービスデプロイを自動化)"
+  ],
+  "dependencies": [
+    {
+      "repo": "tramli",
+      "direction": "depends_on",
+      "capability": "state machine engine (FlowDefinition, FlowEngine, plugins)",
+      "exists_now": true,
+      "note": "pom.xml 依存。認証フロー定義・実行の中核"
+    },
+    {
+      "repo": "tramli-plugins",
+      "direction": "depends_on",
+      "capability": "audit / lint / observability plugins",
+      "exists_now": true,
+      "note": "pom.xml 依存。全フローに横断的関心事を適用"
+    },
+    {
+      "repo": "volta-gateway",
+      "direction": "depends_on",
+      "capability": "認証サーバ（Rust 版後継）— 同等の X-Volta-* ヘッダを生成",
+      "exists_now": true,
+      "note": "catalog で active。本リポジトリは retired で、後継が稼働中"
+    },
+    {
+      "repo": "volta-auth-console",
+      "direction": "provides_to",
+      "capability": "Internal API (/api/v1/*) — 管理コンソールがユーザー・テナント・セッション・監査ログを操作",
+      "exists_now": true,
+      "note": "React 製管理 UI。本プロキシの API を消費"
+    },
+    {
+      "repo": "nanori-site",
+      "direction": "provides_to",
+      "capability": "認証（管理コンソール /admin/ が volta-auth 認証 + owner トークンを使用）",
+      "exists_now": true,
+      "note": "catalog に記載。nanori が認証を委譲している可能性がある"
+    }
+  ],
+  "library_serve": {
+    "needed": false,
+    "new_work": [],
+    "runtime": "java",
+    "estimated_effort": "S"
+  },
+  "risks": [
+    "operational_status=retired: catalog で退役扱い。後継 volta-auth-server (Rust) が active。MCP ラップを付けても本番運用に乗らない可能性がある",
+    "秘密情報: JWT_KEY_ENCRYPTION_SECRET, VOLTA_SERVICE_TOKEN, Google/Microsoft/GitHub/Apple client secret, Stripe secret key 等の環境変数を扱う。MCP 経由で漏洩しないよう注意",
+    "破壊的操作: アカウント削除(GDPR), 鍵ローテーション, メンバー削除, セッション失効等。confirm パラメータを必須にすべき",
+    "外部 API 課金: Stripe (billing), Google/Microsoft OIDC (API クォータ), Fraud Alert (FRAUD_ALERT_URL) 等",
+    "認証コンテキスト: MCP tool 経由の呼び出しでいかに JWT/cookie を適切に扱うかが課題。エージェントがセッション cookie を保持する形は不自然。M2M トークン(issue_m2m_token)を前段に使う形が現実的"
+  ],
+  "open_questions": [
+    "retired 確定か? 後継 volta-auth-server (Rust) に機能が完全に移行済みなら、このリポジトリの MCP 化は skip にすべき",
+    "もし MCP 化するなら、認証コンテキストをどう渡すか（M2M トークン発行→tool 呼び出しの 2 段階？ユーザー JWT を外部から注入？）",
+    "volta-auth-console (React 管理UI) との役割分担。MCP tool は管理UIがやることを代替するのか、それとも API 経由の自動化用途か",
+    "後継 volta-auth-server (Rust) 側に MCP を付ける方が適切ではないか（active な方に投資すべき）"
+  ]
+}

--- a/docs/skills/operate-auth-proxy/SKILL.md
+++ b/docs/skills/operate-auth-proxy/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: operate-auth-proxy
+description: volta-auth-proxy MCP (namespace=auth) 経由で認証・テナント・セッション・監査ログを操作する手順
+volta:
+  version: 1
+  namespace: auth
+  locality: service
+  applies_when:
+    - repo.has_file("mcp/server.mjs")
+  requires:
+    tools:
+      - auth__issue_m2m_token
+      - auth__get_current_user
+  min_role: MEMBER
+  export: false
+  tags: [auth, ops, mcp]
+---
+
+# volta-auth-proxy 運用手順
+
+> この手順は resource `skill://operate-auth-proxy` でも配信される。
+
+## 1. M2M トークンの発行
+
+`auth__issue_m2m_token` に `{client_id, client_secret}` を渡して `access_token` を取得する。
+
+```
+auth__issue_m2m_token({ client_id: "...", client_secret: "..." })
+→ { access_token: "eyJ...", token_type: "Bearer", expires_in: 3600, scope: "..." }
+```
+
+## 2. 読み取り操作
+
+`auth__get_current_user`, `auth__list_user_tenants`, `auth__list_sessions` 等の `jwt` パラメータに M2M トークンを渡す。
+
+```
+auth__get_current_user({ jwt: "<access_token>" })
+→ { id, email, displayName, tenantId, roles }
+```
+
+## 3. 破壊的操作
+
+以下の tool は `confirm: true` で実行。未指定なら dry-run（対象と予定を返す）。
+
+- `auth__remove_member` — メンバー削除
+- `auth__revoke_all_sessions` — 全セッション失効
+- `auth__rotate_signing_key` — 署名鍵ローテーション（OWNER 権限）
+- `auth__request_account_deletion` — GDPR アカウント削除
+- `auth__change_member_role` — ロール変更
+- `auth__cancel_invitation` — 招待キャンセル
+- `auth__revoke_session` — 個別セッション失効
+
+## 4. 監査ログ
+
+`auth__list_audit_logs` で操作履歴を確認。ADMIN 権限が必要。
+
+## 5. 認証フロー可視化
+
+`auth__list_flow_definitions`（公開、JWT 不要）でフロー定義の mermaid 図を取得。
+
+## 6. 注意
+
+- この MCP は `volta-auth-proxy` (Java/Javalin, port 7070) の REST API を wrap している
+- catalog 上 `operational_status: retired`。後継の `volta-auth-server` (Rust) が active
+- 後継系の操作は `vgw` namespace（vgw-mcp）を優先し、旧版固有の機能の補完として `auth` を使う
+- JWT/secret は MCP 経由で露出しない（tool パラメータとして渡すが、サーバログには出力しない）

--- a/infra/logrotate/volta-auth-proxy
+++ b/infra/logrotate/volta-auth-proxy
@@ -1,0 +1,20 @@
+# volta-auth-proxy のアプリログを回転させる。
+#
+# 導入 (root):
+#   sudo cp infra/logrotate/volta-auth-proxy /etc/logrotate.d/volta-auth-proxy
+#   sudo logrotate -d /etc/logrotate.d/volta-auth-proxy   # dry-run で確認
+#
+# start-dev.sh は `>> logs/auth-proxy.log` で追記する (O_APPEND) ため、
+# copytruncate で inode を保ったまま切り詰める。JVM の再起動は不要。
+
+/home/opa/work/volta-workspace/volta-auth-proxy/logs/*.log {
+    daily
+    rotate 7
+    size 100M
+    copytruncate
+    compress
+    delaycompress
+    missingok
+    notifempty
+    su opa opa
+}

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -1,0 +1,519 @@
+#!/usr/bin/env node
+import http from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+function log(...a) {
+  process.stderr.write('[auth-mcp] ' + a.map((x) => typeof x === 'string' ? x : JSON.stringify(x)).join(' ') + '\n');
+}
+
+const BACKEND_URL = process.env.AUTH_BACKEND_URL || 'http://127.0.0.1:7070';
+const PORT = parseInt(process.env.PORT || '9211', 10);
+const BIND = '0.0.0.0';
+const VERSION = '0.1.0';
+
+async function backendFetch(path, opts = {}) {
+  const url = `${BACKEND_URL}${path}`;
+  const headers = { 'content-type': 'application/json', ...opts.headers };
+  if (opts.jwt) headers['authorization'] = `Bearer ${opts.jwt}`;
+  if (opts.cookie) headers['cookie'] = opts.cookie;
+  const res = await fetch(url, {
+    method: opts.method || 'GET',
+    headers,
+    body: opts.body ? JSON.stringify(opts.body) : undefined,
+  });
+  const text = await res.text();
+  let json;
+  try { json = JSON.parse(text); } catch { json = { _raw: text }; }
+  return { status: res.status, body: json };
+}
+
+function ok(data) {
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+}
+function err(status, body) {
+  return { isError: true, content: [{ type: 'text', text: JSON.stringify({ error: true, status, body }) }] };
+}
+function dryRun(action, params) {
+  return { content: [{ type: 'text', text: JSON.stringify({ dryRun: true, action, params, message: 'confirm: true で実行します' }) }] };
+}
+
+function createServer() {
+  const server = new McpServer({ name: 'auth-mcp', version: VERSION });
+
+  // --- read tools ---
+
+  server.tool('verify_session', 'セッションを検証して X-Volta-* ヘッダ情報を返す（read, ForwardAuth 用）', {
+    cookie: z.string().describe('ブラウザセッション cookie 文字列'),
+  }, async (args) => {
+    const r = await backendFetch('/auth/verify', { cookie: args.cookie });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('refresh_token', 'JWT をリフレッシュする（write）', {
+    jwt: z.string().describe('現在の JWT'),
+  }, async (args) => {
+    const r = await backendFetch('/auth/refresh', { method: 'POST', jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('issue_m2m_token', 'M2M クライアント認証でトークンを発行する（write, POST /oauth/token）', {
+    client_id: z.string().describe('M2M クライアント ID'),
+    client_secret: z.string().describe('M2M クライアントシークレット'),
+    scope: z.string().optional().describe('要求するスコープ（省略可）'),
+    audience: z.string().optional().describe('対象サービス（省略可）'),
+  }, async (args) => {
+    const r = await backendFetch('/oauth/token', {
+      method: 'POST',
+      body: {
+        grant_type: 'client_credentials',
+        client_id: args.client_id,
+        client_secret: args.client_secret,
+        ...(args.scope && { scope: args.scope }),
+        ...(args.audience && { audience: args.audience }),
+      },
+    });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('get_current_user', '現在のユーザー情報を取得する（read）', {
+    jwt: z.string().describe('access_token (JWT)'),
+  }, async (args) => {
+    const r = await backendFetch('/api/v1/users/me', { jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('list_user_tenants', 'ユーザーが所属するテナント一覧を取得する（read）', {
+    jwt: z.string(),
+  }, async (args) => {
+    const r = await backendFetch('/api/v1/users/me/tenants', { jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('get_tenant', 'テナント情報を取得する（read）', {
+    jwt: z.string(),
+    tenantId: z.string(),
+  }, async (args) => {
+    const r = await backendFetch(`/api/v1/tenants/${encodeURIComponent(args.tenantId)}`, { jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('list_tenant_members', 'テナントメンバー一覧を取得する（read, ページネーション可）', {
+    jwt: z.string(),
+    tenantId: z.string(),
+    offset: z.number().optional(),
+    limit: z.number().optional(),
+  }, async (args) => {
+    const params = new URLSearchParams();
+    if (args.offset != null) params.set('offset', String(args.offset));
+    if (args.limit != null) params.set('limit', String(args.limit));
+    const qs = params.toString();
+    const r = await backendFetch(`/api/v1/tenants/${encodeURIComponent(args.tenantId)}/members${qs ? '?' + qs : ''}`, { jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  // --- write/destructive tools (confirm required) ---
+
+  server.tool('change_member_role', 'メンバーロールを変更する（write, confirm 必須）', {
+    jwt: z.string(),
+    tenantId: z.string(),
+    memberId: z.string(),
+    role: z.string().describe('新しいロール (MEMBER/ADMIN/OWNER)'),
+    confirm: z.boolean().optional().describe('true で実行。未指定なら dry-run'),
+  }, async (args) => {
+    const { confirm, ...params } = args;
+    if (!confirm) return dryRun('change_member_role', params);
+    const r = await backendFetch(`/api/v1/tenants/${encodeURIComponent(args.tenantId)}/members/${encodeURIComponent(args.memberId)}`, {
+      method: 'PATCH', jwt: args.jwt, body: { role: args.role },
+    });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('remove_member', 'メンバーをテナントから削除する（destructive, confirm 必須）', {
+    jwt: z.string(),
+    tenantId: z.string(),
+    memberId: z.string(),
+    confirm: z.boolean().optional(),
+  }, async (args) => {
+    const { confirm, ...params } = args;
+    if (!confirm) return dryRun('remove_member', params);
+    const r = await backendFetch(`/api/v1/tenants/${encodeURIComponent(args.tenantId)}/members/${encodeURIComponent(args.memberId)}`, {
+      method: 'DELETE', jwt: args.jwt,
+    });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('create_invitation', 'テナントに招待を作成する（write）', {
+    jwt: z.string(),
+    tenantId: z.string(),
+    email: z.string().optional(),
+    role: z.string().optional(),
+    max_uses: z.number().optional(),
+    expires_in_hours: z.number().optional(),
+  }, async (args) => {
+    const r = await backendFetch(`/api/v1/tenants/${encodeURIComponent(args.tenantId)}/invitations`, {
+      method: 'POST', jwt: args.jwt, body: {
+        ...(args.email && { email: args.email }),
+        ...(args.role && { role: args.role }),
+        ...(args.max_uses != null && { max_uses: args.max_uses }),
+        ...(args.expires_in_hours != null && { expires_in_hours: args.expires_in_hours }),
+      },
+    });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('list_invitations', 'テナントの招待一覧を取得する（read）', {
+    jwt: z.string(),
+    tenantId: z.string(),
+    status: z.string().optional(),
+  }, async (args) => {
+    const params = new URLSearchParams();
+    if (args.status) params.set('status', args.status);
+    const qs = params.toString();
+    const r = await backendFetch(`/api/v1/tenants/${encodeURIComponent(args.tenantId)}/invitations${qs ? '?' + qs : ''}`, { jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('cancel_invitation', '招待をキャンセルする（write, confirm 必須）', {
+    jwt: z.string(),
+    tenantId: z.string(),
+    invitationId: z.string(),
+    confirm: z.boolean().optional(),
+  }, async (args) => {
+    const { confirm, ...params } = args;
+    if (!confirm) return dryRun('cancel_invitation', params);
+    const r = await backendFetch(`/api/v1/tenants/${encodeURIComponent(args.tenantId)}/invitations/${encodeURIComponent(args.invitationId)}`, {
+      method: 'DELETE', jwt: args.jwt,
+    });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('list_sessions', 'セッション一覧を取得する（read）', {
+    jwt: z.string(),
+  }, async (args) => {
+    const r = await backendFetch('/api/v1/users/me/sessions', { jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('revoke_session', 'セッションを失効する（write, confirm 必須）', {
+    jwt: z.string(),
+    sessionId: z.string(),
+    confirm: z.boolean().optional(),
+  }, async (args) => {
+    const { confirm, ...params } = args;
+    if (!confirm) return dryRun('revoke_session', params);
+    const r = await backendFetch(`/api/v1/users/me/sessions/${encodeURIComponent(args.sessionId)}`, {
+      method: 'DELETE', jwt: args.jwt,
+    });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('revoke_all_sessions', '全セッションを失効する（destructive, confirm 必須）', {
+    jwt: z.string(),
+    confirm: z.boolean().optional(),
+  }, async (args) => {
+    const { confirm, ...params } = args;
+    if (!confirm) return dryRun('revoke_all_sessions', params);
+    const r = await backendFetch('/api/me/sessions', { method: 'DELETE', jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('mfa_setup', 'MFA (TOTP) セットアップを開始する（write）', {
+    jwt: z.string(),
+    userId: z.string(),
+  }, async (args) => {
+    const r = await backendFetch(`/api/v1/users/${encodeURIComponent(args.userId)}/mfa/totp/setup`, {
+      method: 'POST', jwt: args.jwt,
+    });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('mfa_verify', 'MFA (TOTP) を検証・有効化する（write）', {
+    jwt: z.string(),
+    userId: z.string(),
+    code: z.string().describe('6 桁の TOTP コード'),
+  }, async (args) => {
+    const r = await backendFetch(`/api/v1/users/${encodeURIComponent(args.userId)}/mfa/totp/verify`, {
+      method: 'POST', jwt: args.jwt, body: { code: args.code },
+    });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('get_mfa_status', 'MFA ステータスを取得する（read）', {
+    jwt: z.string(),
+  }, async (args) => {
+    const r = await backendFetch('/api/v1/users/me/mfa', { jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('rotate_signing_key', '署名鍵をローテーションする（destructive, confirm 必須, OWNER 権限）', {
+    jwt: z.string(),
+    confirm: z.boolean().optional(),
+  }, async (args) => {
+    const { confirm, ...params } = args;
+    if (!confirm) return dryRun('rotate_signing_key', params);
+    const r = await backendFetch('/api/v1/admin/keys/rotate', { method: 'POST', jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('list_audit_logs', '監査ログを取得する（read, ADMIN 権限, ページネーション可）', {
+    jwt: z.string(),
+    tenantId: z.string().optional(),
+    from: z.string().optional().describe('ISO 日時'),
+    to: z.string().optional().describe('ISO 日時'),
+    event: z.string().optional(),
+    offset: z.number().optional(),
+    limit: z.number().optional(),
+  }, async (args) => {
+    const params = new URLSearchParams();
+    if (args.tenantId) params.set('tenantId', args.tenantId);
+    if (args.from) params.set('from', args.from);
+    if (args.to) params.set('to', args.to);
+    if (args.event) params.set('event', args.event);
+    if (args.offset != null) params.set('offset', String(args.offset));
+    if (args.limit != null) params.set('limit', String(args.limit));
+    const qs = params.toString();
+    const r = await backendFetch(`/api/v1/admin/audit${qs ? '?' + qs : ''}`, { jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('list_flow_definitions', '認証フロー定義一覧を取得する（read, 公開）', {}, async () => {
+    const r = await backendFetch('/viz/flows');
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('list_flows', '認証フロー実行一覧を取得する（read, ADMIN 権限）', {
+    jwt: z.string(),
+    tenant_id: z.string().optional(),
+    flow_type: z.string().optional(),
+    since: z.string().optional(),
+    limit: z.number().optional(),
+  }, async (args) => {
+    const params = new URLSearchParams();
+    if (args.tenant_id) params.set('tenant_id', args.tenant_id);
+    if (args.flow_type) params.set('flow_type', args.flow_type);
+    if (args.since) params.set('since', args.since);
+    if (args.limit != null) params.set('limit', String(args.limit));
+    const qs = params.toString();
+    const r = await backendFetch(`/api/v1/admin/flows${qs ? '?' + qs : ''}`, { jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('get_flow_transitions', 'フロー遷移履歴を取得する（read, ADMIN 権限）', {
+    jwt: z.string(),
+    flowId: z.string(),
+  }, async (args) => {
+    const r = await backendFetch(`/api/v1/admin/flows/${encodeURIComponent(args.flowId)}/transitions`, { jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('export_user_data', 'GDPR データエクスポート（read）', {
+    jwt: z.string(),
+  }, async (args) => {
+    const r = await backendFetch('/api/v1/users/me/data-export', { method: 'POST', jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  server.tool('request_account_deletion', 'GDPR 削除要求（destructive, confirm 必須）', {
+    jwt: z.string(),
+    confirm: z.boolean().optional(),
+  }, async (args) => {
+    const { confirm, ...params } = args;
+    if (!confirm) return dryRun('request_account_deletion', params);
+    const r = await backendFetch('/api/v1/users/me', { method: 'DELETE', jwt: args.jwt });
+    return r.status === 200 ? ok(r.body) : err(r.status, r.body);
+  });
+
+  // --- resources ---
+
+  server.resource('spec', 'auth://spec', { mimeType: 'application/json', description: '能力の機械可読仕様' }, async () => {
+    const spec = buildSpec();
+    return { contents: [{ uri: 'auth://spec', mimeType: 'application/json', text: JSON.stringify(spec, null, 2) }] };
+  });
+
+  server.resource('guide', 'auth://guide', { mimeType: 'text/markdown', description: 'auth MCP の使い方ガイド' }, async () => {
+    const guide = [
+      '# auth MCP ガイド',
+      '',
+      '## 基本フロー: M2M トークン → API 呼び出し',
+      '',
+      '1. `auth__issue_m2m_token` で `{client_id, client_secret}` を渡し、`access_token` を取得する',
+      '2. 以降の tool 呼び出しの `jwt` パラメータにその `access_token` を渡す',
+      '3. 破壊的操作（`remove_member`, `revoke_all_sessions`, `rotate_signing_key`, `request_account_deletion` 等）は `confirm: true` で実行。未指定なら dry-run（対象と予定を返す）',
+      '',
+      '## 組み合わせ例',
+      '',
+      '- `auth__issue_m2m_token → auth__get_current_user → auth__list_user_tenants` — ユーザー情報とテナント一覧の取得',
+      '- `auth__list_audit_logs → index__agent_fork` — 監査ログから不審アクティビティ検知で調査エージェント起動',
+      '- `auth__list_flow_definitions → design__get_component_snippet` — 認証フロー図を UI コンポーネントで可視化',
+      '',
+      '## 注意',
+      '',
+      '- このサーバは `volta-auth-proxy` (Java/Javalin, port 7070) の REST API を wrap している',
+      '- catalog 上 `operational_status: retired`。後継の `volta-auth-server` (Rust) が active',
+      '- JWT/secret は MCP 経由で露出しない（tool パラメータとして渡すが、サーバログには出力しない）',
+    ].join('\n');
+    return { contents: [{ uri: 'auth://guide', mimeType: 'text/markdown', text: guide }] };
+  });
+
+  server.resource('jwks', 'auth://jwks', { mimeType: 'application/json', description: 'JWKS 公開鍵' }, async () => {
+    const r = await backendFetch('/.well-known/jwks.json');
+    return { contents: [{ uri: 'auth://jwks', mimeType: 'application/json', text: JSON.stringify(r.body, null, 2) }] };
+  });
+
+  server.resource('flows', 'auth://flows', { mimeType: 'application/json', description: '認証フロー図 (mermaid + stateDiagram)' }, async () => {
+    const r = await backendFetch('/viz/flows');
+    return { contents: [{ uri: 'auth://flows', mimeType: 'application/json', text: JSON.stringify(r.body, null, 2) }] };
+  });
+
+  // --- skill resource ---
+  server.resource('operate-auth-proxy', 'skill://operate-auth-proxy', { mimeType: 'text/markdown', description: 'skill: volta-auth-proxy の運用手順' }, async () => {
+    const skill = [
+      '---',
+      'name: operate-auth-proxy',
+      'description: volta-auth-proxy MCP 経由で認証・テナント・セッション・監査ログを操作する手順',
+      'volta:',
+      '  version: 1',
+      '  namespace: auth',
+      '  locality: service',
+      '  applies_when: [repo.has_file("mcp/server.mjs")]',
+      '  requires:',
+      '    tools: [auth__issue_m2m_token, auth__get_current_user]',
+      '  min_role: MEMBER',
+      '  tags: [auth, ops]',
+      '---',
+      '# volta-auth-proxy 運用手順',
+      '',
+      '## 1. M2M トークンの発行',
+      '`auth__issue_m2m_token` に `{client_id, client_secret}` を渡して `access_token` を取得する。',
+      '',
+      '## 2. 読み取り操作',
+      '`auth__get_current_user`, `auth__list_user_tenants`, `auth__list_sessions` 等の `jwt` パラメータに M2M トークンを渡す。',
+      '',
+      '## 3. 破壊的操作',
+      '`remove_member`, `revoke_all_sessions`, `rotate_signing_key`, `request_account_deletion` は `confirm: true` で実行。',
+      '未指定なら dry-run（対象と予定を返す）。',
+      '',
+      '## 4. 監査ログ',
+      '`auth__list_audit_logs` で操作履歴を確認。ADMIN 権限が必要。',
+      '',
+    ].join('\n');
+    return { contents: [{ uri: 'skill://operate-auth-proxy', mimeType: 'text/markdown', text: skill }] };
+  });
+
+  return server;
+}
+
+function buildSpec() {
+  return {
+    namespace: 'auth',
+    name: 'auth-mcp',
+    version: VERSION,
+    summary: 'volta-auth-proxy (Java/Javalin) の REST API を MCP で wrap する。M2M トークン発行→認証・テナント・セッション・監査操作。',
+    capabilities: [
+      { kind: 'tool', name: 'verify_session', summary: 'セッション検証 (ForwardAuth)', input: '{cookie}', output: '{userId,tenantId,roles,jwt,appId}|401', side_effect: 'read', long_running: false, dry_run: false, min_role: 'VIEWER' },
+      { kind: 'tool', name: 'refresh_token', summary: 'JWT リフレッシュ', input: '{jwt}', output: '{token,expires_in}', side_effect: 'write', long_running: false, dry_run: false, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'issue_m2m_token', summary: 'M2M トークン発行', input: '{client_id,client_secret,scope?,audience?}', output: '{access_token,token_type,expires_in,scope}', side_effect: 'write', long_running: false, dry_run: false, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'get_current_user', summary: 'ユーザー情報取得', input: '{jwt}', output: '{id,email,displayName,tenantId,roles}', side_effect: 'read', long_running: false, dry_run: false, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'list_user_tenants', summary: 'テナント一覧', input: '{jwt}', output: '{data:[{id,name,slug,role,isLast}]}', side_effect: 'read', long_running: false, dry_run: false, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'get_tenant', summary: 'テナント情報', input: '{jwt,tenantId}', output: 'tenantDetail', side_effect: 'read', long_running: false, dry_run: false, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'list_tenant_members', summary: 'メンバー一覧', input: '{jwt,tenantId,offset?,limit?}', output: 'paginated', side_effect: 'read', long_running: false, dry_run: false, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'change_member_role', summary: 'ロール変更', input: '{jwt,tenantId,memberId,role,confirm?}', output: '{ok}|dry-run', side_effect: 'write', long_running: false, dry_run: true, min_role: 'ADMIN' },
+      { kind: 'tool', name: 'remove_member', summary: 'メンバー削除', input: '{jwt,tenantId,memberId,confirm?}', output: '{ok}|dry-run', side_effect: 'destructive', long_running: false, dry_run: true, min_role: 'ADMIN' },
+      { kind: 'tool', name: 'create_invitation', summary: '招待作成', input: '{jwt,tenantId,email?,role?,...}', output: '{id,code,link,expiresAt}', side_effect: 'write', long_running: false, dry_run: false, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'list_invitations', summary: '招待一覧', input: '{jwt,tenantId,status?}', output: 'paginated', side_effect: 'read', long_running: false, dry_run: false, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'cancel_invitation', summary: '招待キャンセル', input: '{jwt,tenantId,invitationId,confirm?}', output: '{ok}|dry-run', side_effect: 'write', long_running: false, dry_run: true, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'list_sessions', summary: 'セッション一覧', input: '{jwt}', output: '{items:[...]}', side_effect: 'read', long_running: false, dry_run: false, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'revoke_session', summary: 'セッション失効', input: '{jwt,sessionId,confirm?}', output: '{ok}|dry-run', side_effect: 'write', long_running: false, dry_run: true, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'revoke_all_sessions', summary: '全セッション失効', input: '{jwt,confirm?}', output: '{ok}|dry-run', side_effect: 'destructive', long_running: false, dry_run: true, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'mfa_setup', summary: 'MFA TOTP セットアップ', input: '{jwt,userId}', output: '{secret,otpauth_url}', side_effect: 'write', long_running: false, dry_run: false, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'mfa_verify', summary: 'MFA TOTP 検証', input: '{jwt,userId,code}', output: '{ok,enabled}', side_effect: 'write', long_running: false, dry_run: false, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'get_mfa_status', summary: 'MFA ステータス', input: '{jwt}', output: '{totp,recovery_codes_remaining}', side_effect: 'read', long_running: false, dry_run: false, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'rotate_signing_key', summary: '署名鍵ローテーション', input: '{jwt,confirm?}', output: '{ok,kid}|dry-run', side_effect: 'destructive', long_running: false, dry_run: true, min_role: 'OWNER' },
+      { kind: 'tool', name: 'list_audit_logs', summary: '監査ログ', input: '{jwt,tenantId?,from?,to?,event?,offset?,limit?}', output: 'paginated', side_effect: 'read', long_running: false, dry_run: false, min_role: 'ADMIN' },
+      { kind: 'tool', name: 'list_flow_definitions', summary: 'フロー定義一覧', input: '{}', output: '{flows:[...]}', side_effect: 'read', long_running: false, dry_run: false, min_role: 'VIEWER' },
+      { kind: 'tool', name: 'list_flows', summary: 'フロー実行一覧', input: '{jwt,tenant_id?,flow_type?,since?,limit?}', output: '{flows:[...]}', side_effect: 'read', long_running: false, dry_run: false, min_role: 'ADMIN' },
+      { kind: 'tool', name: 'get_flow_transitions', summary: 'フロー遷移履歴', input: '{jwt,flowId}', output: '{flowId,transitions:[...]}', side_effect: 'read', long_running: false, dry_run: false, min_role: 'ADMIN' },
+      { kind: 'tool', name: 'export_user_data', summary: 'GDPR データエクスポート', input: '{jwt}', output: 'JSON', side_effect: 'read', long_running: false, dry_run: false, min_role: 'MEMBER' },
+      { kind: 'tool', name: 'request_account_deletion', summary: 'GDPR 削除要求', input: '{jwt,confirm?}', output: '{status,delete_at}|dry-run', side_effect: 'destructive', long_running: false, dry_run: true, min_role: 'MEMBER' },
+      { kind: 'resource', name: 'spec', summary: '能力仕様', input: '-', output: 'JSON', side_effect: 'none', long_running: false, dry_run: false, min_role: 'VIEWER' },
+      { kind: 'resource', name: 'guide', summary: '使い方ガイド', input: '-', output: 'markdown', side_effect: 'none', long_running: false, dry_run: false, min_role: 'VIEWER' },
+      { kind: 'resource', name: 'jwks', summary: 'JWKS 公開鍵', input: '-', output: 'JSON', side_effect: 'none', long_running: false, dry_run: false, min_role: 'VIEWER' },
+      { kind: 'resource', name: 'flows', summary: '認証フロー図', input: '-', output: 'JSON', side_effect: 'none', long_running: false, dry_run: false, min_role: 'VIEWER' },
+      { kind: 'skill', name: 'operate-auth-proxy', summary: '運用手順', input: '-', output: 'markdown', side_effect: 'none', long_running: false, dry_run: false, min_role: 'MEMBER' },
+    ],
+    compositions: [
+      { title: 'M2M トークン → ユーザー情報', flow: ['auth__issue_m2m_token', 'auth__get_current_user', 'auth__list_user_tenants'], note: 'M2M トークンを発行し、ユーザー情報とテナント一覧を取得' },
+      { title: '監査ログ → 調査エージェント', flow: ['auth__list_audit_logs', 'index__agent_fork'], note: '監査ログから不審アクティビティ検知で調査エージェント起動' },
+      { title: 'フロー定義 → UI 可視化', flow: ['auth__list_flow_definitions', 'design__get_component_snippet'], note: '認証フロー図を UI コンポーネントで可視化' },
+    ],
+    depends_on: [
+      { namespace: 'index', capability: 'index__agent_fork' },
+      { namespace: 'design', capability: 'design__get_component_snippet' },
+    ],
+    health: '/healthz',
+    docs: ['auth://guide', 'auth://spec'],
+  };
+}
+
+// --- HTTP server (Streamable HTTP) ---
+
+async function serveHttp(port) {
+  const transports = new Map();
+  const httpServer = http.createServer(async (req, res) => {
+    res.setHeader('content-encoding', 'identity');
+    const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+    try {
+      if (url.pathname === '/healthz') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        return res.end(JSON.stringify({ ok: true, name: 'auth-mcp', version: VERSION }));
+      }
+      if (url.pathname !== '/mcp') {
+        res.writeHead(404, { 'content-type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'not found' }));
+      }
+      const sid = req.headers['mcp-session-id'];
+      if (sid && transports.has(sid)) {
+        return await transports.get(sid).handleRequest(req, res);
+      }
+      if (req.method === 'POST' && !sid) {
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          enableJsonResponse: true,
+          onsessioninitialized: (id) => { transports.set(id, transport); log('session open', { sid: id }); },
+          onsessionclosed: (id) => { transports.delete(id); log('session closed', { sid: id }); },
+        });
+        const server = createServer();
+        transport.onclose = () => {
+          if (transport.sessionId) transports.delete(transport.sessionId);
+          server.close().catch(() => {});
+        };
+        await server.connect(transport);
+        return await transport.handleRequest(req, res);
+      }
+      res.writeHead(sid ? 404 : 400, { 'content-type': 'application/json' });
+      return res.end(JSON.stringify({ error: sid ? 'unknown session' : 'missing mcp-session-id' }));
+    } catch (e) {
+      log('request failed', { path: url.pathname, error: String(e?.stack || e) });
+      if (!res.headersSent) { res.writeHead(500); res.end(JSON.stringify({ error: 'internal error' })); }
+      else res.end();
+    }
+  });
+  httpServer.listen(port, BIND, () => log('http listening', { url: `http://${BIND}:${port}/mcp` }));
+}
+
+async function serveStdio() {
+  const server = createServer();
+  await server.connect(new StdioServerTransport());
+  log('stdio started');
+}
+
+const argv = process.argv.slice(2);
+if (argv.includes('--stdio')) {
+  serveStdio().catch((e) => { log('stdio failed', { error: String(e?.stack || e) }); process.exit(1); });
+} else {
+  serveHttp(PORT).catch((e) => { log('http failed', { error: String(e?.stack || e) }); process.exit(1); });
+}

--- a/mcp/test/e2e.mjs
+++ b/mcp/test/e2e.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+let serverProc;
+let exitCode = 0;
+const PORT = 19211;
+const BASE = `http://127.0.0.1:${PORT}`;
+const failures = [];
+
+function assert(cond, msg) {
+  if (!cond) { failures.push(msg); console.error('FAIL:', msg); }
+  else console.log('ok  :', msg);
+}
+
+async function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+async function withRetry(fn, retries = 10, delay = 300) {
+  for (let i = 0; i < retries; i++) {
+    try { return await fn(); } catch (e) {
+      if (i === retries - 1) throw e;
+      await sleep(delay);
+    }
+  }
+}
+
+async function main() {
+  serverProc = spawn('node', ['mcp/server.mjs'], {
+    env: { ...process.env, PORT: String(PORT), AUTH_BACKEND_URL: 'http://127.0.0.1:7070' },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  serverProc.stderr.on('data', (d) => process.stderr.write(d));
+  serverProc.stdout.on('data', (d) => process.stdout.write(d));
+
+  await sleep(500);
+
+  try {
+    await withRetry(async () => {
+      const r = await fetch(`${BASE}/healthz`);
+      assert(r.status === 200, '/healthz returns 200');
+      const j = await r.json();
+      assert(j.ok === true, 'healthz body {ok:true}');
+      assert(j.name === 'auth-mcp', 'healthz body name=auth-mcp');
+    });
+
+    const transport = new StreamableHTTPClientTransport(new URL(`${BASE}/mcp`));
+    const client = new Client({ name: 'test-client', version: '0.1.0' });
+    await withRetry(async () => { await client.connect(transport); }, 8, 400);
+    console.log('ok  : MCP client connected');
+
+    const tools = await client.listTools();
+    const toolNames = tools.tools.map((t) => t.name);
+    const expectedTools = [
+      'verify_session', 'refresh_token', 'issue_m2m_token', 'get_current_user',
+      'list_user_tenants', 'get_tenant', 'list_tenant_members', 'change_member_role',
+      'remove_member', 'create_invitation', 'list_invitations', 'cancel_invitation',
+      'list_sessions', 'revoke_session', 'revoke_all_sessions',
+      'mfa_setup', 'mfa_verify', 'get_mfa_status',
+      'rotate_signing_key', 'list_audit_logs',
+      'list_flow_definitions', 'list_flows', 'get_flow_transitions',
+      'export_user_data', 'request_account_deletion',
+    ];
+    for (const t of expectedTools) {
+      assert(toolNames.includes(t), `tool "${t}" present in tools/list`);
+    }
+    assert(toolNames.length >= expectedTools.length, `tools/list has ${toolNames.length} tools (>= ${expectedTools.length})`);
+
+    const confirmTools = ['change_member_role', 'remove_member', 'cancel_invitation', 'revoke_session', 'revoke_all_sessions', 'rotate_signing_key', 'request_account_deletion'];
+    for (const t of confirmTools) {
+      const tool = tools.tools.find((x) => x.name === t);
+      assert(tool?.inputSchema?.properties?.confirm !== undefined, `"${t}" has confirm param`);
+    }
+
+    const dryRes = await client.callTool({ name: 'rotate_signing_key', arguments: { jwt: 'test' } });
+    const dryText = dryRes.content?.[0]?.text;
+    const dryJson = JSON.parse(dryText);
+    assert(dryJson.dryRun === true, 'rotate_signing_key dry-run when confirm omitted');
+    assert(dryJson.action === 'rotate_signing_key', 'dry-run returns action name');
+
+    const resSpec = await client.readResource({ uri: 'auth://spec' });
+    const specText = resSpec.contents[0]?.text;
+    const spec = JSON.parse(specText);
+    assert(spec.namespace === 'auth', 'spec resource namespace=auth');
+    assert(Array.isArray(spec.capabilities), 'spec has capabilities array');
+    assert(Array.isArray(spec.compositions), 'spec has compositions array');
+    assert(spec.health === '/healthz', 'spec health=/healthz');
+
+    const resGuide = await client.readResource({ uri: 'auth://guide' });
+    const guideText = resGuide.contents[0]?.text;
+    assert(guideText?.includes('# auth MCP'), 'guide resource has title');
+    assert(guideText?.includes('M2M'), 'guide mentions M2M');
+
+    const resSkill = await client.readResource({ uri: 'skill://operate-auth-proxy' });
+    const skillText = resSkill.contents[0]?.text;
+    assert(skillText?.includes('name: operate-auth-proxy'), 'skill resource has frontmatter');
+    assert(skillText?.includes('volta:'), 'skill has volta frontmatter');
+
+    await client.close();
+    console.log('ok  : MCP client disconnected');
+  } catch (e) {
+    console.error('ERROR:', e?.stack || e);
+    failures.push(String(e?.message || e));
+  } finally {
+    if (serverProc) serverProc.kill('SIGTERM');
+  }
+
+  if (failures.length > 0) {
+    console.error(`\n${failures.length} FAILURES:`);
+    failures.forEach((f) => console.error('  -', f));
+    exitCode = 1;
+  } else {
+    console.log('\nALL TESTS PASSED');
+  }
+  process.exit(exitCode);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@unlaxer/dde-toolkit": "^0.1.4",
     "@unlaxer/dge-toolkit": "^4.2.0",
     "@unlaxer/dre-toolkit": "^4.1.2",
-    "@unlaxer/dxe-suite": "^4.1.3"
+    "@unlaxer/dxe-suite": "^4.1.3",
+    "zod": "^4.4.3"
   }
 }

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec node mcp/server.mjs

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -375,10 +375,10 @@ sequenceDiagram
 **登録フロー:**
 
 ```
-POST /auth/passkey/register/start
+POST /api/v1/users/{userId}/passkeys/register/start
   → PublicKeyCredentialCreationOptions (challenge, rp, user, pubKeyCredParams)
-POST /auth/passkey/register/finish (attestation)
-  → Yubico webauthn4j で attestation 検証
+POST /api/v1/users/{userId}/passkeys/register/finish (attestation)
+  → webauthn4j で attestation 検証
   → user_passkeys テーブルに credential_id + public_key 保存
 ```
 
@@ -1608,11 +1608,11 @@ VIEWER:
 
 | Method | Path | 説明 |
 |---|---|---|
-| POST | `/api/v1/users/me/mfa/totp/enroll` | TOTP QR/secret 取得 |
-| POST | `/api/v1/users/me/mfa/totp/activate` | TOTP コード検証 + 有効化 |
-| DELETE | `/api/v1/users/me/mfa/totp` | TOTP 無効化 |
-| GET | `/api/v1/users/me/mfa/recovery-codes` | リカバリーコード一覧 |
-| POST | `/api/v1/users/me/mfa/recovery-codes/regenerate` | リカバリーコード再生成 |
+| POST | `/api/v1/users/{userId}/mfa/totp/setup` | TOTP QR/secret 取得 |
+| POST | `/api/v1/users/{userId}/mfa/totp/verify` | TOTP コード検証 + 有効化 |
+| DELETE | `/api/v1/users/{userId}/mfa/totp` | TOTP 無効化 |
+| GET | `/api/v1/users/me/mfa` | TOTP 状態・残りリカバリーコード数 |
+| POST | `/api/v1/users/{userId}/mfa/recovery-codes/regenerate` | リカバリーコード再生成 |
 
 ### 6.3 AdminRouter (`/admin/*`)
 

--- a/src/main/java/org/unlaxer/infra/volta/Main.java
+++ b/src/main/java/org/unlaxer/infra/volta/Main.java
@@ -557,14 +557,47 @@ public final class Main {
             actionHref = "/";
             actionLabel = "しばらく待って再試行";
         }
-        ctx.status(status).render("error/error.jte", model(
-                "title", "エラー",
-                "errorCode", code,
-                "message", userMessage,
-                "actions", List.of(Map.of("label", actionLabel, "url", actionHref, "style", "primary")),
-                "showSupport", List.of("SESSION_REVOKED", "TENANT_SUSPENDED", "INTERNAL_ERROR").contains(code),
-                "supportContact", System.getenv().getOrDefault("SUPPORT_CONTACT", "管理者にお問い合わせください")
-        ));
+        try {
+            ctx.status(status).render("error/error.jte", model(
+                    "title", "エラー",
+                    "errorCode", code,
+                    "message", userMessage,
+                    "actions", List.of(Map.of("label", actionLabel, "url", actionHref, "style", "primary")),
+                    "showSupport", List.of("SESSION_REVOKED", "TENANT_SUSPENDED", "INTERNAL_ERROR").contains(code),
+                    "supportContact", System.getenv().getOrDefault("SUPPORT_CONTACT", "管理者にお問い合わせください")
+            ));
+        } catch (Exception renderFailure) {
+            // テンプレート描画自体が壊れているとエラー画面が一切出せず、
+            // 例外がそのままログに落ち続ける。静的HTMLへフォールバックする。
+            // (スタックトレースは出さない: エラー経路ごとに巨大ログを吐くため)
+            System.getLogger("volta").log(System.Logger.Level.WARNING,
+                    "error page template render failed (" + code + "): "
+                            + renderFailure.getClass().getName() + ": " + renderFailure.getMessage());
+            ctx.status(status).contentType("text/html; charset=utf-8")
+                    .result(staticErrorPage(code, userMessage, actionHref, actionLabel));
+        }
+    }
+
+    /** error/error.jte が描画できないときのフォールバック。依存ゼロの静的HTML。 */
+    private static String staticErrorPage(String code, String message, String actionHref, String actionLabel) {
+        return """
+                <!DOCTYPE html>
+                <html lang="ja"><head><meta charset="utf-8">
+                <meta name="viewport" content="width=device-width,initial-scale=1">
+                <title>エラー</title></head>
+                <body style="font-family:system-ui,sans-serif;max-width:32rem;margin:4rem auto;padding:0 1rem">
+                <h1 style="font-size:1.25rem">エラー</h1>
+                <p>%s</p>
+                <p style="color:#666;font-size:.85rem">コード: %s</p>
+                <p><a href="%s">%s</a></p>
+                </body></html>
+                """.formatted(escapeHtml(message), escapeHtml(code), escapeHtml(actionHref), escapeHtml(actionLabel));
+    }
+
+    private static String escapeHtml(String s) {
+        if (s == null) return "";
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                .replace("\"", "&quot;").replace("'", "&#39;");
     }
 
     private static String humanMessage(String code, String fallback) {

--- a/src/main/java/org/unlaxer/infra/volta/SqlStore.java
+++ b/src/main/java/org/unlaxer/infra/volta/SqlStore.java
@@ -2568,9 +2568,10 @@ public final class SqlStore {
         String token = SecurityUtils.randomUrlSafe(48);
         try (Connection conn = dataSource.getConnection();
              PreparedStatement ps = conn.prepareStatement(
-                     "INSERT INTO magic_links (email, token, expires_at) VALUES (?, ?, now() + interval '" + ttlMinutes + " minutes')")) {
+                     "INSERT INTO magic_links (email, token, expires_at) VALUES (?, ?, now() + (? || ' minutes')::interval)")) {
             ps.setString(1, email);
             ps.setString(2, token);
+            ps.setInt(3, ttlMinutes);
             ps.executeUpdate();
             return token;
         } catch (SQLException e) {

--- a/src/main/java/org/unlaxer/infra/volta/flow/FlowDataRegistry.java
+++ b/src/main/java/org/unlaxer/infra/volta/flow/FlowDataRegistry.java
@@ -2,6 +2,7 @@ package org.unlaxer.infra.volta.flow;
 import org.unlaxer.tramli.FlowException;
 import org.unlaxer.tramli.FlowContext;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.HashMap;
@@ -15,6 +16,10 @@ public final class FlowDataRegistry {
     private final Map<String, Class<?>> aliasByName = new HashMap<>();
     private final Map<Class<?>, String> nameByAlias = new HashMap<>();
     private final ObjectMapper objectMapper;
+
+    // Reusable TypeReference for Map<String, Object> — avoids per-call
+    // TypeFactory.constructType(Map.class) overhead in convertValue.
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REF = new TypeReference<>() {};
 
     public FlowDataRegistry(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
@@ -56,7 +61,7 @@ public final class FlowDataRegistry {
         for (var entry : ctx.snapshot().entrySet()) {
             String alias = nameByAlias.get(entry.getKey());
             if (alias != null) {
-                result.put(alias, objectMapper.convertValue(entry.getValue(), Map.class));
+                result.put(alias, objectMapper.convertValue(entry.getValue(), MAP_TYPE_REF));
             }
         }
         return result;

--- a/src/main/java/org/unlaxer/infra/volta/flow/SensitiveRedactor.java
+++ b/src/main/java/org/unlaxer/infra/volta/flow/SensitiveRedactor.java
@@ -4,6 +4,8 @@ import org.unlaxer.tramli.FlowContext;
 import java.lang.reflect.RecordComponent;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Redacts @Sensitive fields from FlowContext snapshots for audit logging.
@@ -13,6 +15,34 @@ public final class SensitiveRedactor {
     private static final String REDACTED = "***REDACTED***";
 
     private SensitiveRedactor() {}
+
+    // Cache of sensitive JSON field names per FlowData record class.
+    // Reflection over RecordComponent + @Sensitive is invariant per class,
+    // so the result is cached once per class and reused across all transitions.
+    // Key: FlowData record class. Value: unmodifiable set of sensitive JSON field names.
+    private static final ConcurrentHashMap<Class<?>, Set<String>> SENSITIVE_CACHE = new ConcurrentHashMap<>();
+
+    private static Set<String> sensitiveFieldNames(Class<?> clazz) {
+        Set<String> cached = SENSITIVE_CACHE.get(clazz);
+        if (cached != null) return cached;
+        java.util.LinkedHashSet<String> names = new java.util.LinkedHashSet<>();
+        if (clazz.isRecord()) {
+            for (RecordComponent component : clazz.getRecordComponents()) {
+                if (component.isAnnotationPresent(Sensitive.class)) {
+                    names.add(component.getName());
+                    var jsonProp = component.getAnnotation(
+                            com.fasterxml.jackson.annotation.JsonProperty.class);
+                    if (jsonProp != null && !jsonProp.value().isEmpty()) {
+                        names.add(jsonProp.value());
+                    }
+                }
+            }
+        }
+        Set<String> immutable = java.util.Collections.unmodifiableSet(names);
+        // putIfAbsent to avoid replacing a concurrently-computed entry
+        Set<String> existing = SENSITIVE_CACHE.putIfAbsent(clazz, immutable);
+        return existing != null ? existing : immutable;
+    }
 
     /**
      * Redact @Sensitive fields from a serialized context map.
@@ -42,30 +72,22 @@ public final class SensitiveRedactor {
     }
 
     private static Map<String, Object> redactFields(Class<?> clazz, Map<?, ?> fields) {
-        Map<String, Object> redacted = new LinkedHashMap<>();
+        Set<String> sensitive = sensitiveFieldNames(clazz);
+        if (sensitive.isEmpty()) {
+            // No sensitive fields on this type — return the input map as-is
+            @SuppressWarnings("unchecked")
+            Map<String, Object> unchecked = (Map<String, Object>) fields;
+            return unchecked;
+        }
+        Map<String, Object> redacted = new LinkedHashMap<>(fields.size());
         for (var entry : fields.entrySet()) {
             String fieldName = String.valueOf(entry.getKey());
-            if (isSensitiveField(clazz, fieldName)) {
+            if (sensitive.contains(fieldName)) {
                 redacted.put(fieldName, REDACTED);
             } else {
                 redacted.put(fieldName, entry.getValue());
             }
         }
         return redacted;
-    }
-
-    private static boolean isSensitiveField(Class<?> clazz, String jsonFieldName) {
-        if (!clazz.isRecord()) return false;
-        for (RecordComponent component : clazz.getRecordComponents()) {
-            // Check @Sensitive on the record component
-            if (component.isAnnotationPresent(Sensitive.class)) {
-                // Match by component name or @JsonProperty value
-                if (component.getName().equals(jsonFieldName)) return true;
-                var jsonProp = component.getAnnotation(
-                        com.fasterxml.jackson.annotation.JsonProperty.class);
-                if (jsonProp != null && jsonProp.value().equals(jsonFieldName)) return true;
-            }
-        }
-        return false;
     }
 }

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# volta-auth-proxy startup — required by volta-gateway (host 192.168.1.8:7070).
+# Idempotent and safe to run repeatedly (cron */1 uses this for crash/boot recovery).
+#
+# NOTE: .env DB_PORT/DB_USER/DB_PASSWORD do NOT match where the real data lives.
+# Real data is in the docker-compose volta-auth-postgres (mapped port 54329, user volta/volta).
+# We override those three vars here while keeping the rest of .env.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# Ensure backing services are up. compose has restart: unless-stopped, but after a
+# fresh boot the daemon may not have started them yet, so start on demand too.
+for c in volta-auth-postgres volta-auth-redis; do
+  if ! docker ps --format '{{.Names}}' | grep -qx "$c"; then
+    docker start "$c" >/dev/null 2>&1 || true
+  fi
+done
+
+# Already running? Match the real jar process cmdline (not this script / cron wrapper).
+if pgrep -f 'java -jar target/volta-auth-proxy-.*\.jar' >/dev/null; then
+  exit 0
+fi
+
+# Wait until postgres actually accepts connections before launching the JVM.
+# The app's Hikari pool fail-fasts (and the process exits) if the DB is still
+# in "the database system is starting up". Bounded so a cron run can't hang.
+for _ in $(seq 1 30); do
+  if [ "$(docker inspect -f '{{.State.Health.Status}}' volta-auth-postgres 2>/dev/null)" = "healthy" ]; then
+    break
+  fi
+  sleep 1
+done
+
+mkdir -p logs
+set -a; . ./.env; set +a
+DB_PORT=54329 DB_USER=volta DB_PASSWORD=volta \
+  nohup java -jar target/volta-auth-proxy-0.3.0-SNAPSHOT.jar \
+  >> logs/auth-proxy.log 2>&1 &
+
+echo "$(date -Is) auth-proxy started, pid=$!, log=logs/auth-proxy.log"

--- a/volta.service.json
+++ b/volta.service.json
@@ -1,0 +1,25 @@
+{
+  "id": "volta-auth-proxy-mcp",
+  "name": "Volta Auth Proxy MCP",
+  "description": "volta-auth-proxy (Java/Javalin) REST API の MCP ラップ。M2M トークン発行→認証・テナント・セッション・監査操作。namespace=auth",
+  "type": "node",
+  "hostname": "auth-mcp.unlaxer.org",
+  "port": 9211,
+  "host": "192.168.1.8",
+  "runtime": "systemd",
+  "exec_start": "/home/opa/volta-auth-proxy/run.sh",
+  "user": "opa",
+  "auth": "minRole:MEMBER",
+  "health_check": "/healthz",
+  "tags": ["mcp", "auth", "identity", "oauth2", "opa"],
+  "repo_url": "https://github.com/opaopa6969/volta-auth-proxy",
+  "mcp": {
+    "enabled": true,
+    "port": 9211,
+    "path": "/mcp",
+    "namespace": "auth",
+    "min_role": "MEMBER",
+    "timeoutMs": 110000,
+    "description": "volta-auth-proxy (Java) REST API の MCP ラップ。M2M トークン発行→認証・テナント・セッション・監査操作"
+  }
+}


### PR DESCRIPTION
## 何を変えたか

- ドキュメントを現行実装へ同期し、magic link TTL のSQL組み立てをbindパラメータ化
- MCPサーバー、E2E確認、運用skill、サービス定義を追加
- JVMヒープ上限とコンテナメモリ上限を設定し、枯渇時の異常状態を長引かせない
- 監査ログ生成のリフレクション・型解析を再利用してCPU負荷を削減
- 開発環境の冪等な自動復旧とログローテーションを追加

## なぜ変えたか

本番・開発環境の停止やメモリ枯渇、ログ肥大化を予防しつつ、状態遷移ごとの監査処理コストを抑えるためです。また、認証機能をMCP経由で安全に運用できる入口と、その設計・状態をリポジトリ内に残します。

## 検証

- GitHub Actions: 成功（Nexus資格情報が無いためJava compile/testはスキップ）
- bash -n start-dev.sh: 成功
- logrotate -d infra/logrotate/volta-auth-proxy: 設定読み込み成功
- git diff --check: 成功