### PR TITLE
perf: /auth/verify のJWT署名負荷をキャッシュで削減

### DIFF
--- a/docs/engine-benchmark-iter1.md
+++ b/docs/engine-benchmark-iter1.md
@@ -1,0 +1,105 @@
+# Engine Benchmark — Iteration 1 Report
+
+Date: 2026-08-16
+Profile: engine-benchmark
+Iteration: 1 of 3
+
+## 観測事実
+
+### アーキテクチャ
+- Java 21.0.9 (Oracle LTS) + Maven 3.9.9 + Javalin 6.7.0 (Jetty-based)
+- tramli 3.7.1 状態機関エンジン (OIDC login / MFA verify のみ使用)
+- Postgres 16 + HikariCP (pool=10, minIdle=2)
+- `/auth/verify` (ForwardAuth, Traefik が全リクエストで呼ぶ) は**手続き型** (tramli 不使用)
+- ホットパス:
+  1. `AuthService.authenticate(ctx)` — セッション Cookie → findSession + findUserById + findTenantById + findMembership + touchSession (4〜5 DBクエリ)
+  2. `JwtService.issueToken(principal)` — **RS256署名を毎リクエスト実行** (JWT TTL=300s=5分)
+
+### Baseline測定（再現可能）
+
+**マイクロベンチ: RS256 JWT署名単体** (`src/test/.../JwtSignBenchmark.java`, `-Dbenchmark=true`)
+- 1署名あたり: **1057.61 μs (約1.06 ms)**
+- シングルスレッドスループット: **946 ops/s**
+- 測定条件: 2048bit RSA, nimbus-jose-jwt 10.5, best of 5 rounds × 20,000 iterations, warmup 2,000
+
+**エンドツーエンド: `/auth/verify`（サービストークン経路、直列300req）**
+- 同一環境: 別ポート 7071, Docker Postgres 54329 (volta/volta), サービストークン認証 (DB不要)
+- Baseline（元コード）:
+  - Mean: **8.456 ms** / p50: 7.591 ms / p90: 13.435 ms / p99: 23.492 ms
+  - 直列スループット: **118 req/s**
+
+## 仮説
+
+`/auth/verify` は毎リクエスト RS256 署名（~1ms）を実行する。同一プリンシパルの JWT は TTL 窓内（5分）でクレームが同一なので、署名済みトークンをキャッシュして再利用すれば、署名コストを削減できる。ログアウト伝播は JWT exp（最大5分）で設計されているため、キャッシュ最大5分は許容範囲。
+
+## 実施内容
+
+`JwtService` に JWT 発行キャッシュを追加:
+- `ConcurrentHashMap<JwtCacheKey, CachedJwt>` を追加
+- キー: `(AuthPrincipal, audience, extraClaims, cacheGeneration)` — レコードで値等価
+- 値: `(token, expiresAt)`
+- ヒット条件: 残存寿命 > 30秒 かつ 鍵ローテーション世代が同一
+- `rotateKey()` で `cacheGeneration++` + `jwtCache.clear()` で無効化
+- 上限 50,000 エントリで全クリア（異常時のメモリ保護）
+- ファイル: `src/main/java/org/unlaxer/infra/volta/JwtService.java`
+
+## 検証結果
+
+**エンドツーエンド: `/auth/verify`（同一環境、改善後、直列300req）**
+
+| 指標 | Baseline | Improved | 改善 |
+|---|---|---|---|
+| Mean | 8.456 ms | **7.083 ms** | **-16.2%** |
+| p50 | 7.591 ms | **5.996 ms** | **-21.0%** |
+| p90 | 13.435 ms | 12.198 ms | -9.2% |
+| p99 | 23.492 ms | 20.185 ms | -14.1% |
+| 直列スループット | 118 req/s | **141 req/s** | **+19.5%** |
+
+改善幅 ~1.4ms は RS256署名の ~1.06ms 削減と整合的（残りはキャッシュ lookup/put オーバーヘッド + 計測ノイズ）。
+
+**並列（10ワーカー、300req、同一環境）**
+
+| 指標 | Baseline | Improved | 改善 |
+|---|---|---|---|
+| Mean | 10.091 ms | **4.504 ms** | **-55.4%** |
+| p50 | 9.484 ms | **3.457 ms** | **-63.6%** |
+| p90 | 18.013 ms | **8.050 ms** | **-55.3%** |
+| p99 | 34.097 ms | **19.789 ms** | **-42.0%** |
+
+並列時の改善が直列より遥かに大きい理由: baseline は毎リクエクト RS256 署名（CPU集約的、~1ms）が並列で CPU を競合しレイテンシが膨らむ。改善後はキャッシュヒットで署名をスキップし CPU 競合が起きないため、並列恩恵がフルに現れる。
+
+テスト: `JwtKeySelectionTest` 4件すべて通過。
+
+## 次の判断
+
+改善あり。Iter2 へ進む。
+
+## 外部データ出典
+
+- RS256署名コストの公表値: 自前マイクロベンチで実測（本環境: 1.06ms/op）。外部公表値との直接比較は環境依存が大きく、TechEmpower Benchmarks の Javalin エントリは存在するが具体的な RS256 署名オーバーヘッドの公表値は得られず。nimbus-jose-jwt 10.5 の `JOSEObjectType.JWT` 定数は javap で存在確認済み。
+  - TechEmpower Framework Benchmarks: https://www.techempower.com/benchmarks/ （取得日 2026-08-16, CC BY 4.0 相当の公開ベンチマーク）
+  - nimbus-jose-jwt 10.5: Apache License 2.0, Maven Central
+
+## 再現手順
+
+```bash
+# 1. Docker Postgres 起動済み (port 54329, volta/volta)
+# 2. baseline jar ビルド（元コード）
+mvn -o package -DskipTests
+cp target/volta-auth-proxy-0.3.0-SNAPSHOT.jar /tmp/volta-baseline.jar
+
+# 3. baseline サーバ起動
+PORT=7071 DB_HOST=127.0.0.1 DB_PORT=54329 DB_NAME=volta_auth DB_USER=volta DB_PASSWORD=volta \
+  JWT_KEY_ENCRYPTION_SECRET=K1-KN-vFgqulrtK_YEmdpF4kXJNXoIL1KlIm9C8Uxhc VOLTA_SERVICE_TOKEN=bench-token \
+  java -jar /tmp/volta-baseline.jar &
+
+# 4. baseline ベンチマーク
+bash tasks/bench-verify.sh 300  # .env の VOLTA_SERVICE_TOKEN を使う版（要調整）
+
+# 5. 改修後 jar ビルド＆起動＆ベンチ（同一手順）
+```
+
+マイクロベンチ:
+```bash
+mvn -o test -Dtest=JwtSignBenchmark -Dbenchmark=true
+```

--- a/src/main/java/org/unlaxer/infra/volta/JwtService.java
+++ b/src/main/java/org/unlaxer/infra/volta/JwtService.java
@@ -46,6 +46,20 @@ public final class JwtService {
     // This is what gets published to the JWKS endpoint.
     private volatile Map<String, RSAKey> verificationKeys;
 
+    // ── JWT issuance cache ──────────────────────────────────────────────
+    // /auth/verify signs a fresh RS256 JWT on every request (~1ms/op). Within
+    // a single JWT TTL window the claims for a given principal are identical,
+    // so the signed token is reusable. This cache returns the previously
+    // signed token when (a) the key hasn't rotated and (b) the remaining
+    // lifetime is above a floor, skipping the RSA sign entirely.
+    // Evicted on key rotation and when the remaining lifetime drops below
+    // the floor. Bounded by the number of distinct active principals, which
+    // is small relative to request volume.
+    private final java.util.concurrent.ConcurrentHashMap<JwtCacheKey, CachedJwt> jwtCache =
+            new java.util.concurrent.ConcurrentHashMap<>();
+    private static final long CACHE_MIN_REMAINING_SECONDS = 30L;
+    private volatile int cacheGeneration = 0;
+
     public JwtService(AppConfig config, SqlStore store) {
         this.config = config;
         this.store = store;
@@ -59,10 +73,25 @@ public final class JwtService {
     }
 
     public String issueToken(AuthPrincipal principal, List<String> audience, Map<String, Object> extraClaims) {
+        List<String> aud = (audience == null || audience.isEmpty()) ? List.of(config.jwtAudience()) : audience;
+        // Cache lookup: the signed token for this exact claim set is reusable
+        // as long as the key hasn't rotated and the remaining lifetime is
+        // above the floor. This skips the ~1ms RS256 sign on /auth/verify.
+        JwtCacheKey key = new JwtCacheKey(principal, aud, extraClaims, cacheGeneration);
+        CachedJwt cached = jwtCache.get(key);
+        if (cached != null) {
+            long remaining = cached.expiresAt().getEpochSecond() - Instant.now().getEpochSecond();
+            if (remaining > CACHE_MIN_REMAINING_SECONDS) {
+                return cached.token();
+            }
+            // expired or near-expiry: drop and re-sign
+            jwtCache.remove(key, cached);
+        }
+
         Instant now = Instant.now();
         JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
                 .issuer(config.jwtIssuer())
-                .audience(audience == null || audience.isEmpty() ? List.of(config.jwtAudience()) : audience)
+                .audience(aud)
                 .subject(principal.userId().toString())
                 .expirationTime(Date.from(now.plusSeconds(config.jwtTtlSeconds())))
                 .issueTime(Date.from(now))
@@ -81,11 +110,23 @@ public final class JwtService {
         JWTClaimsSet claims = builder.build();
         try {
             SignedJWT jwt = new SignedJWT(
-                    new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(rsaKey.getKeyID()).type(JOSEObjectType.JWT).build(),
+                    new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(rsaKey.getKeyID()).type(com.nimbusds.jose.JOSEObjectType.JWT).build(),
                     claims
             );
             jwt.sign(new RSASSASigner(rsaKey.toPrivateKey()));
-            return jwt.serialize();
+            String token = jwt.serialize();
+            // Populate cache. Token expires at now + jwtTtlSeconds.
+            Instant exp = now.plusSeconds(config.jwtTtlSeconds());
+            CachedJwt entry = new CachedJwt(token, exp);
+            // Guard against unbounded growth: if the cache is very large, clear
+            // stale entries first. The realistic cardinality is the number of
+            // concurrently active principals, which is small, but a defensive
+            // bound keeps memory predictable under abuse.
+            if (jwtCache.size() > 50_000) {
+                jwtCache.clear();
+            }
+            jwtCache.put(key, entry);
+            return token;
         } catch (JOSEException e) {
             throw new RuntimeException(e);
         }
@@ -259,6 +300,10 @@ public final class JwtService {
             // Reload so the new active key and the just-retired (rotated) key are
             // both present in the verification set / JWKS during the grace period.
             this.verificationKeys = loadVerificationKeys();
+            // Invalidate the JWT issuance cache: any cached token was signed
+            // with the retiring key and must not be handed out again.
+            this.cacheGeneration++;
+            this.jwtCache.clear();
             return kid;
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -278,4 +323,18 @@ public final class JwtService {
         );
         return issueToken(principal, audience, Map.of("volta_client", true, "volta_client_id", clientId));
     }
+
+    // ── JWT issuance cache types ────────────────────────────────────────
+    // Cache key: the exact claim set that determines a signed token, plus a
+    // generation counter that bumps on key rotation. Records give us value
+    // equality on principal (record) + audience (List) + extraClaims (Map) +
+    // generation (int), which is what we need for a stable cache key.
+    private record JwtCacheKey(
+            AuthPrincipal principal,
+            List<String> audience,
+            Map<String, Object> extraClaims,
+            int generation
+    ) {}
+
+    private record CachedJwt(String token, Instant expiresAt) {}
 }

--- a/src/test/java/org/unlaxer/infra/volta/JwtSignBenchmark.java
+++ b/src/test/java/org/unlaxer/infra/volta/JwtSignBenchmark.java
@@ -1,0 +1,108 @@
+package org.unlaxer.infra.volta;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Microbenchmark for RS256 JWT signing — the hot path of /auth/verify.
+ *
+ * Run with: mvn test -Dtest=JwtSignBenchmark -Dbenchmark=true
+ * Disabled by default; only runs when -Dbenchmark=true is set so CI is unaffected.
+ */
+@EnabledIfSystemProperty(named = "benchmark", matches = "true")
+class JwtSignBenchmark {
+
+    @Test
+    void measureRs256SignThroughput() throws Exception {
+        RSAKey key = generateKey("bench-key");
+        RSASSASigner signer = new RSASSASigner(key.toPrivateKey());
+
+        // Warmup
+        for (int i = 0; i < 2_000; i++) {
+            signOnce(signer, key.getKeyID());
+        }
+
+        // Measure
+        int iterations = 20_000;
+        long[] nanos = new long[iterations];
+        // avoid GC noise: run a few rounds, take the best
+        long bestTotal = Long.MAX_VALUE;
+        int rounds = 5;
+        for (int r = 0; r < rounds; r++) {
+            long start = System.nanoTime();
+            for (int i = 0; i < iterations; i++) {
+                signOnce(signer, key.getKeyID());
+            }
+            long total = System.nanoTime() - start;
+            if (total < bestTotal) bestTotal = total;
+        }
+
+        double avgNanos = bestTotal / (double) iterations;
+        double opsPerSec = 1_000_000_000.0 / avgNanos;
+        double avgMicros = avgNanos / 1000.0;
+
+        System.out.println();
+        System.out.println("=== RS256 JWT sign benchmark ===");
+        System.out.printf("Iterations per round : %,d%n", iterations);
+        System.out.printf("Rounds (best of)    : %d%n", rounds);
+        System.out.printf("Avg per sign        : %.2f us%n", avgMicros);
+        System.out.printf("Throughput (single) : %,.0f ops/s%n", opsPerSec);
+        System.out.printf("Total (best round)  : %.3f ms%n", bestTotal / 1_000_000.0);
+        System.out.println("================================");
+    }
+
+    private static String signOnce(RSASSASigner signer, String kid) throws JOSEException {
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer("volta-auth")
+                .audience(List.of("volta-apps"))
+                .subject(UUID.randomUUID().toString())
+                .expirationTime(new Date(now.getTime() + 300_000))
+                .issueTime(now)
+                .jwtID(UUID.randomUUID().toString())
+                .claim("volta_v", 1)
+                .claim("volta_tid", UUID.randomUUID().toString())
+                .claim("volta_roles", List.of("MEMBER"))
+                .claim("volta_display", "bench-user")
+                .claim("volta_tname", "tenant")
+                .claim("volta_tslug", "slug")
+                .build();
+        SignedJWT jwt = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(kid).type(JOSEObjectType.JWT).build(),
+                claims
+        );
+        jwt.sign(signer);
+        return jwt.serialize();
+    }
+
+    private static RSAKey generateKey(String kid) {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            KeyPair kp = generator.generateKeyPair();
+            return new RSAKey.Builder((RSAPublicKey) kp.getPublic())
+                    .privateKey((RSAPrivateKey) kp.getPrivate())
+                    .keyID(kid)
+                    .algorithm(JWSAlgorithm.RS256)
+                    .build();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tasks/bench-verify.sh
+++ b/tasks/bench-verify.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# End-to-end /auth/verify benchmark (single-threaded, serial).
+# Uses the service-token path so we exercise JWT signing without needing
+# an OIDC login. Override via env vars:
+#   VOLTA_URL (default http://localhost:7070)
+#   VOLTA_SERVICE_TOKEN (required)
+#   N (default 300)
+set -u
+
+URL="${VOLTA_URL:-http://localhost:7070}/auth/verify"
+TOKEN="${VOLTA_SERVICE_TOKEN:?set VOLTA_SERVICE_TOKEN}"
+N="${N:-300}"
+AUTH="Authorization: Bearer volta-service:${TOKEN}"
+
+echo "=== /auth/verify serial benchmark ==="
+echo "URL: ${URL}"
+echo "N:  ${N}"
+
+# Warmup (let JIT settle, prime any cache)
+for i in $(seq 1 20); do
+  curl -s -m 5 -o /dev/null -H "${AUTH}" "${URL}" || true
+done
+
+# Verify 200
+code=$(curl -s -m 5 -o /dev/null -w "%{http_code}" -H "${AUTH}" "${URL}")
+if [ "${code}" != "200" ]; then
+  echo "ERROR: verify returned ${code}, expected 200"
+  exit 1
+fi
+
+# Measure
+TMP=$(mktemp)
+for i in $(seq 1 ${N}; ); do
+  curl -s -m 10 -o /dev/null -w "%{time_total}\n" -H "${AUTH}" "${URL}" >> "${TMP}"
+done
+
+awk '
+  { ms = $1 * 1000; sum += ms; n++; a[n] = ms; if (ms > max) max = ms; if (min=="" || ms < min) min = ms }
+  END {
+    asort(a)
+    printf "N         : %d\n", n
+    printf "Mean      : %.3f ms\n", sum/n
+    printf "Min       : %.3f ms\n", min
+    printf "Max       : %.3f ms\n", max
+    printf "p50       : %.3f ms\n", a[int(n*0.5)+1]
+    printf "p90       : %.3f ms\n", a[int(n*0.9)+1]
+    printf "p99       : %.3f ms\n", a[int(n*0.99)+1]
+    printf "Throughput: %.0f req/s (serial)\n", 1000/(sum/n)
+  }
+' "${TMP}"
+rm -f "${TMP}"
+echo "=========================================="


### PR DESCRIPTION
## 変更内容
- 主体・audience・追加クレーム・鍵世代ごとに署名済み JWT を再利用
- 有効期限30秒前で再署名し、鍵ローテーション時にキャッシュを即時破棄
- 5万件の上限でメモリ増加を防止
- マイクロベンチ、E2E計測スクリプト、測定資料を追加

## 変更理由
ForwardAuth の `/auth/verify` が同一クレームをリクエストごとに RS256 署名しており、CPU負荷と応答時間を増やしていたためです。

## 検証
- `docker run ... maven:3.9-eclipse-temurin-21 mvn test -q --settings .mvn/settings.xml` 成功
- `git diff --check` 成功