### PR TITLE
fix: harden SAML mock and RelayState validation

### DIFF
--- a/docs/getting-started-ja.md
+++ b/docs/getting-started-ja.md
@@ -197,16 +197,24 @@ nginx 背面時の `/auth/*` ルーティング修正は `afb6eab` 参照。
 2. **Single sign-on URL (ACS)**: `https://auth.example.com/auth/saml/callback`
 3. **Audience URI (SP Entity ID)**: `volta-sp-audience`
 4. Name ID 形式: `EmailAddress`
-5. Okta metadata XML をエクスポート → volta admin に登録:
+5. Okta の署名証明書をエクスポートし、テナント IdP API に登録して、
+   署名検証を有効のままにする:
 
 ```bash
-curl -X POST https://auth.example.com/admin/idp \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -F "kind=SAML" \
-  -F "issuer=http://www.okta.com/exk..." \
-  -F "audience=volta-sp-audience" \
-  -F "x509Cert=@okta.cer"
+jq -n --rawfile cert okta.cer \
+  --arg issuer "http://www.okta.com/exk..." \
+  '{provider_type:"SAML", issuer:$issuer, client_id:"volta-sp-audience", x509_cert:$cert}' \
+  | curl -X POST "https://auth.example.com/api/v1/tenants/$TENANT_ID/idp-configs" \
+      -H "Authorization: Bearer $ADMIN_TOKEN" \
+      -H "Content-Type: application/json" \
+      --data-binary @-
+
+# 本番および外部到達可能な環境では必ずこの値を使用する。
+SAML_SKIP_SIGNATURE=false
 ```
+
+既存環境を `SAML_SKIP_SIGNATURE=true` から移行した場合は volta を再起動し、
+新しい SAML ログインを完了して登録証明書を検証する。
 
 volta は全アサーションに対し **XXE / XSW** 対策を強制する ——
 [auth-flows-ja.md](auth-flows-ja.md#saml-xswxxe-テストカバー状況) 参照。

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -198,16 +198,24 @@ See `afb6eab` for the nginx routing fix that handles `/auth/*` routes correctly.
 2. **Single sign-on URL (ACS)**: `https://auth.example.com/auth/saml/callback`
 3. **Audience URI (SP Entity ID)**: `volta-sp-audience`
 4. Name ID format: `EmailAddress`
-5. Export the Okta metadata XML, register it in volta admin:
+5. Export the Okta signing certificate, register it through the tenant IdP API,
+   and keep signature verification enabled:
 
 ```bash
-curl -X POST https://auth.example.com/admin/idp \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -F "kind=SAML" \
-  -F "issuer=http://www.okta.com/exk..." \
-  -F "audience=volta-sp-audience" \
-  -F "x509Cert=@okta.cer"
+jq -n --rawfile cert okta.cer \
+  --arg issuer "http://www.okta.com/exk..." \
+  '{provider_type:"SAML", issuer:$issuer, client_id:"volta-sp-audience", x509_cert:$cert}' \
+  | curl -X POST "https://auth.example.com/api/v1/tenants/$TENANT_ID/idp-configs" \
+      -H "Authorization: Bearer $ADMIN_TOKEN" \
+      -H "Content-Type: application/json" \
+      --data-binary @-
+
+# Production and externally reachable environments must use this value.
+SAML_SKIP_SIGNATURE=false
 ```
+
+After changing an existing setup from `SAML_SKIP_SIGNATURE=true`, restart volta
+and complete a fresh SAML login to verify the configured certificate.
 
 volta enforces **XXE / XSW** defences on every assertion — see
 [auth-flows.md](auth-flows.md#saml-xswxxe-test-coverage).

--- a/src/main/java/org/unlaxer/infra/volta/Main.java
+++ b/src/main/java/org/unlaxer/infra/volta/Main.java
@@ -57,7 +57,7 @@ public final class Main {
         AuthService authService = new AuthService(config, store, jwtService, sessionStore, globalTenancy);
         KeyCipher secretCipher = new KeyCipher(config.jwtKeyEncryptionSecret());
         OidcService oidcService = new OidcService(config, store, voltaConfig, secretCipher);
-        SamlService samlService = new SamlService();
+        SamlService samlService = new SamlService(config.authFlowHmacKey());
         AppRegistry appRegistry = new AppRegistry(config);
         AuditSink auditSink = AuditSink.create(config);
         NotificationService notificationService = NotificationService.create(config);

--- a/src/main/java/org/unlaxer/infra/volta/SamlService.java
+++ b/src/main/java/org/unlaxer/infra/volta/SamlService.java
@@ -22,6 +22,11 @@ import java.util.Map;
 
 final class SamlService {
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String relayStateHmacKey;
+
+    SamlService(String relayStateHmacKey) {
+        this.relayStateHmacKey = relayStateHmacKey;
+    }
 
     SamlIdentity parseIdentity(
             String samlResponseB64,
@@ -181,7 +186,10 @@ final class SamlService {
     String encodeRelayState(Map<String, Object> relay) {
         try {
             String json = objectMapper.writeValueAsString(relay);
-            return Base64.getUrlEncoder().withoutPadding().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+            String payload = Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(json.getBytes(StandardCharsets.UTF_8));
+            String signature = SecurityUtils.hmacSha256Hex(relayStateHmacKey, payload);
+            return payload + "." + signature;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -189,18 +197,35 @@ final class SamlService {
 
     RelayState decodeRelayState(String relayStateRaw) {
         if (relayStateRaw == null || relayStateRaw.isBlank()) {
-            return new RelayState(null, null, null);
+            throw invalidRelayState();
         }
         try {
-            byte[] decoded = Base64.getUrlDecoder().decode(relayStateRaw);
+            int separator = relayStateRaw.lastIndexOf('.');
+            if (separator <= 0 || separator == relayStateRaw.length() - 1) {
+                throw invalidRelayState();
+            }
+            String payload = relayStateRaw.substring(0, separator);
+            String signature = relayStateRaw.substring(separator + 1);
+            String expectedSignature = SecurityUtils.hmacSha256Hex(relayStateHmacKey, payload);
+            if (!SecurityUtils.constantTimeEquals(expectedSignature, signature)) {
+                throw invalidRelayState();
+            }
+
+            byte[] decoded = Base64.getUrlDecoder().decode(payload);
             JsonNode node = objectMapper.readTree(new String(decoded, StandardCharsets.UTF_8));
             String tenantId = node.path("tenant_id").isMissingNode() ? null : node.path("tenant_id").asText(null);
             String returnTo = node.path("return_to").isMissingNode() ? null : node.path("return_to").asText(null);
             String requestId = node.path("request_id").isMissingNode() ? null : node.path("request_id").asText(null);
             return new RelayState(tenantId, returnTo, requestId);
+        } catch (ApiException e) {
+            throw e;
         } catch (Exception e) {
-            return new RelayState(null, relayStateRaw, null);
+            throw invalidRelayState();
         }
+    }
+
+    private static ApiException invalidRelayState() {
+        return new ApiException(400, "SAML_INVALID_RELAY_STATE", "RelayState is invalid or unsigned");
     }
 
     /** #33: Document 全体ではなく「署名対象要素」を起点に探せるよう Node を取る。 */

--- a/src/main/java/org/unlaxer/infra/volta/SamlService.java
+++ b/src/main/java/org/unlaxer/infra/volta/SamlService.java
@@ -10,6 +10,7 @@ import javax.xml.crypto.dsig.XMLSignature;
 import javax.xml.crypto.dsig.XMLSignatureFactory;
 import javax.xml.crypto.dsig.dom.DOMValidateContext;
 import java.io.ByteArrayInputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -37,8 +38,7 @@ final class SamlService {
         if (devMode && xml.startsWith("MOCK:")) {
             // Only allow MOCK SAML in development with explicit DEV_MODE=true AND non-production base URL
             String baseUrl = System.getenv("BASE_URL");
-            boolean isLocalDev = baseUrl == null || baseUrl.contains("localhost") || baseUrl.contains("127.0.0.1");
-            if (!isLocalDev) {
+            if (!isLocalDevBaseUrl(baseUrl)) {
                 throw new ApiException(400, "SAML_INVALID_RESPONSE", "MOCK SAML not allowed in production");
             }
             String email = xml.substring("MOCK:".length()).trim();
@@ -163,6 +163,18 @@ final class SamlService {
             throw e;
         } catch (Exception e) {
             throw new ApiException(400, "SAML_INVALID_RESPONSE", "invalid saml response");
+        }
+    }
+
+    static boolean isLocalDevBaseUrl(String baseUrl) {
+        if (baseUrl == null) {
+            return true;
+        }
+        try {
+            String host = URI.create(baseUrl).getHost();
+            return "localhost".equals(host) || "127.0.0.1".equals(host);
+        } catch (IllegalArgumentException e) {
+            return false;
         }
     }
 

--- a/src/test/java/org/unlaxer/infra/volta/SamlServiceTest.java
+++ b/src/test/java/org/unlaxer/infra/volta/SamlServiceTest.java
@@ -12,7 +12,8 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.*;
 
 final class SamlServiceTest {
-    private final SamlService service = new SamlService();
+    private static final String RELAY_STATE_KEY = "test-relay-state-hmac-key";
+    private final SamlService service = new SamlService(RELAY_STATE_KEY);
     private final SqlStore.IdpConfigRecord idp = new SqlStore.IdpConfigRecord(
             UUID.randomUUID(),
             UUID.randomUUID(),
@@ -81,6 +82,36 @@ final class SamlServiceTest {
         assertEquals("11111111-1111-1111-1111-111111111111", state.tenantId());
         assertEquals("https://app.example.com/path", state.returnTo());
         assertNull(state.requestId());
+    }
+
+    @Test
+    void rejectsTamperedRelayState() {
+        String encoded = service.encodeRelayState(Map.of("tenant_id", "original-tenant"));
+        String tampered = (encoded.charAt(0) == 'A' ? "B" : "A") + encoded.substring(1);
+
+        ApiException ex = assertThrows(ApiException.class, () -> service.decodeRelayState(tampered));
+        assertEquals(400, ex.status());
+        assertEquals("SAML_INVALID_RELAY_STATE", ex.code());
+    }
+
+    @Test
+    void rejectsUnsignedRelayState() {
+        String unsigned = Base64.getUrlEncoder().withoutPadding().encodeToString(
+                "{\"tenant_id\":\"attacker-controlled\"}".getBytes(StandardCharsets.UTF_8));
+
+        ApiException ex = assertThrows(ApiException.class, () -> service.decodeRelayState(unsigned));
+        assertEquals(400, ex.status());
+        assertEquals("SAML_INVALID_RELAY_STATE", ex.code());
+    }
+
+    @Test
+    void rejectsRelayStateSignedWithDifferentKey() {
+        String encoded = service.encodeRelayState(Map.of("tenant_id", "original-tenant"));
+        SamlService serviceWithDifferentKey = new SamlService("different-relay-state-hmac-key");
+
+        ApiException ex = assertThrows(ApiException.class,
+                () -> serviceWithDifferentKey.decodeRelayState(encoded));
+        assertEquals("SAML_INVALID_RELAY_STATE", ex.code());
     }
 
     @Test

--- a/src/test/java/org/unlaxer/infra/volta/SamlServiceTest.java
+++ b/src/test/java/org/unlaxer/infra/volta/SamlServiceTest.java
@@ -34,6 +34,18 @@ final class SamlServiceTest {
     }
 
     @Test
+    void allowsMockSamlOnlyForExactLocalHosts() {
+        assertTrue(SamlService.isLocalDevBaseUrl(null));
+        assertTrue(SamlService.isLocalDevBaseUrl("http://localhost:7070"));
+        assertTrue(SamlService.isLocalDevBaseUrl("http://127.0.0.1:7070"));
+
+        assertFalse(SamlService.isLocalDevBaseUrl("https://localhost.attacker.com"));
+        assertFalse(SamlService.isLocalDevBaseUrl("https://evil-127.0.0.1.example.com"));
+        assertFalse(SamlService.isLocalDevBaseUrl("https://example.com/path/localhost"));
+        assertFalse(SamlService.isLocalDevBaseUrl("not a valid base url"));
+    }
+
+    @Test
     void parsesSamlXmlIdentity() {
         String xml = """
                 <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">


### PR DESCRIPTION
## Summary

- parse `BASE_URL` and allow MOCK SAML only when the URL host exactly matches `localhost` or `127.0.0.1`
- sign RelayState payloads with the existing `AUTH_FLOW_HMAC_KEY` and reject unsigned, malformed, tampered, or wrong-key values with HTTP 400
- correct the English/Japanese SAML certificate registration and signature-verification migration steps

## Verification

- `docker run --rm -v "$PWD:/app" -w /app maven:3.9-eclipse-temurin-21-alpine mvn -q test --settings .mvn/settings.xml`
- 259 tests, 0 failures, 0 errors, 0 skipped

## Deployment note

Unsigned RelayState values already in flight at deployment time will be rejected. Users can restart the SAML login flow to obtain a signed value. Keep `AUTH_FLOW_HMAC_KEY` stable across instances and register the IdP signing certificate before setting `SAML_SKIP_SIGNATURE=false`.

Closes #58
Closes #64