### PR TITLE
fix(outbox): advance attempt_count on processing exception

### DIFF
--- a/src/main/java/org/unlaxer/infra/volta/OutboxWorker.java
+++ b/src/main/java/org/unlaxer/infra/volta/OutboxWorker.java
@@ -86,15 +86,25 @@ final class OutboxWorker implements AutoCloseable {
                 store.markOutboxPublished(outbox.id());
                 return;
             }
-            int nextAttempt = outbox.attemptCount() + 1;
-            if (nextAttempt >= Math.max(1, config.webhookRetryMax())) {
+            RetryDecision retry = computeRetry(outbox.attemptCount(), config.webhookRetryMax());
+            if (retry.giveUp()) {
                 store.markOutboxPublished(outbox.id());
                 return;
             }
-            Instant nextAt = Instant.now().plusSeconds(backoffSeconds(nextAttempt));
-            store.markOutboxRetry(outbox.id(), nextAttempt, nextAt, "delivery failed");
+            store.markOutboxRetry(outbox.id(), retry.nextAttempt(), retry.nextAt(), "delivery failed");
         } catch (Exception e) {
+            // processNotification と対称にリトライ管理を行う。
+            // ここに到達するのは配信以外の DB 操作(listWebhooks / insertWebhookDelivery /
+            // markOutboxRetry 等)が例外を投げたとき。clearOutboxLock だけだと
+            // attempt_count が進まず毎 tick で無限再取得されるため (#71)。
             store.clearOutboxLock(outbox.id());
+            RetryDecision retry = computeRetry(outbox.attemptCount(), config.webhookRetryMax());
+            if (retry.giveUp()) {
+                store.markOutboxPublished(outbox.id());
+                return;
+            }
+            store.markOutboxRetry(outbox.id(), retry.nextAttempt(), retry.nextAt(),
+                    "processing exception: " + e.getMessage());
         }
     }
 
@@ -144,13 +154,12 @@ final class OutboxWorker implements AutoCloseable {
             }
             store.markOutboxPublished(outbox.id());
         } catch (Exception e) {
-            int nextAttempt = outbox.attemptCount() + 1;
-            if (nextAttempt >= Math.max(1, config.webhookRetryMax())) {
+            RetryDecision retry = computeRetry(outbox.attemptCount(), config.webhookRetryMax());
+            if (retry.giveUp()) {
                 store.markOutboxPublished(outbox.id());
                 return;
             }
-            Instant nextAt = Instant.now().plusSeconds(backoffSeconds(nextAttempt));
-            store.markOutboxRetry(outbox.id(), nextAttempt, nextAt, "notification failed: " + e.getMessage());
+            store.markOutboxRetry(outbox.id(), retry.nextAttempt(), retry.nextAt(), "notification failed: " + e.getMessage());
         }
     }
 
@@ -184,6 +193,22 @@ final class OutboxWorker implements AutoCloseable {
             default -> 1800;
         };
     }
+
+    /**
+     * 次のリトライを判定する。attemptCount を進め、webhookRetryMax に達したら
+     * 打ち切り(giveUp=true)、未達なら backoff 適用済みの nextAt を返す。
+     * process と processNotification で同一ロジックを共有する (#71)。
+     */
+    static RetryDecision computeRetry(int attemptCount, int webhookRetryMax) {
+        int nextAttempt = attemptCount + 1;
+        if (nextAttempt >= Math.max(1, webhookRetryMax)) {
+            return new RetryDecision(true, nextAttempt, null);
+        }
+        Instant nextAt = Instant.now().plusSeconds(backoffSeconds(nextAttempt));
+        return new RetryDecision(false, nextAttempt, nextAt);
+    }
+
+    record RetryDecision(boolean giveUp, int nextAttempt, Instant nextAt) {}
 
     private static boolean acceptsEvent(String eventsCsv, String eventType) {
         if (eventsCsv == null || eventsCsv.isBlank()) {

--- a/src/test/java/org/unlaxer/infra/volta/OutboxWorkerRetryTest.java
+++ b/src/test/java/org/unlaxer/infra/volta/OutboxWorkerRetryTest.java
@@ -1,0 +1,60 @@
+package org.unlaxer.infra.volta;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Issue #71: OutboxWorker 外側 catch でのリトライ管理 — computeRetry が
+ * attemptCount を進め、webhookRetryMax 到達で打ち切り、未達なら backoff 適用済み
+ * nextAt を返すことを検証する。
+ */
+class OutboxWorkerRetryTest {
+
+    @Test
+    void advancesAttemptAndAppliesBackoff() {
+        OutboxWorker.RetryDecision r = OutboxWorker.computeRetry(0, 3);
+        assertEquals(1, r.nextAttempt());
+        assertTrue(!r.giveUp());
+        assertNotNull(r.nextAt());
+        // backoff(1) = 60s → nextAt は約60秒後
+        assertTrue(r.nextAt().isAfter(Instant.now().plusSeconds(55)));
+        assertTrue(r.nextAt().isBefore(Instant.now().plusSeconds(65)));
+    }
+
+    @Test
+    void secondRetryUsesLongerBackoff() {
+        OutboxWorker.RetryDecision r = OutboxWorker.computeRetry(1, 3);
+        assertEquals(2, r.nextAttempt());
+        assertTrue(!r.giveUp());
+        // backoff(2) = 300s
+        assertTrue(r.nextAt().isAfter(Instant.now().plusSeconds(295)));
+    }
+
+    @Test
+    void givesUpAtRetryMax() {
+        OutboxWorker.RetryDecision r = OutboxWorker.computeRetry(2, 3);
+        assertEquals(3, r.nextAttempt());
+        assertTrue(r.giveUp());
+        assertNull(r.nextAt());
+    }
+
+    @Test
+    void givesUpWhenRetryMaxIsOne() {
+        // webhookRetryMax=1 → 初回失敗で即打ち切り
+        OutboxWorker.RetryDecision r = OutboxWorker.computeRetry(0, 1);
+        assertTrue(r.giveUp());
+        assertNull(r.nextAt());
+    }
+
+    @Test
+    void negativeRetryMaxClampedToOne() {
+        OutboxWorker.RetryDecision r = OutboxWorker.computeRetry(0, -1);
+        assertTrue(r.giveUp());
+    }
+}


### PR DESCRIPTION
Closes #71

## What

`OutboxWorker.process` の外側 catch が `clearOutboxLock` だけでリトライ管理(`markOutboxRetry`)を呼んでいなかったため、DB 操作の例外時に `attempt_count` が進まず毎 tick で無限再取得されていた。`processNotification` の catch と対称に `markOutboxRetry` を呼び `attempt_count` を進め、`backoffSeconds` で `next_attempt_at` を設定、`webhookRetryMax` 到達で `markOutboxPublished` で打ち切るよう修正。

## Why

配信失敗(`deliver` の HTTP エラー)だけなら正規経路(`allOk=false` → `markOutboxRetry`)に入るが、`markWebhookFailure` / `insertWebhookDelivery` / `markOutboxRetry` 自体が SQLException を投げると外側 catch に到達する。本番でよく起きる(DB 一時障害・接続枯渇・ロック競合)。このとき `clearOutboxLock` だけだと `processing_until` だけ NULL に戻り、次 tick で即再取得 → 永遠に5秒ごとに再試行され worker スループットを食いつぶす。

## How (最小・安全・可逆)

- リトリアウト判定ロジック(`nextAttempt` 計算 + `webhookRetryMax` 超過判定 + `nextAt` 算出)を `computeRetry` static helper に切り出し
- `process` 正常系 / `process` catch / `processNotification` catch の3箇所で共有(重複排除)
- `computeRetry` + `RetryDecision` を package-private にして単体テスト可能に
- `backoffSeconds` 適用・上限打ち切り・clamped retryMax を5テストで検証

## 備考(判断)

`SqlStore` が `final` かつ Mockito 未導入のため、`process` の結合テスト(実際の DB 操作で例外を起こして `markOutboxRetry` 呼び出しを確認)は困難。代わりにリトライ判定ロジックを static に切り出して単体テストで検証し、`process` / `processNotification` が同じ helper を使うことで対称性を構造的に保証した。

## Verification

```
mvn test  →  Tests run: 274, Failures: 0, Errors: 0, Skipped: 0
```

revert は `git revert <merge-commit>` で可逆。