### PR TITLE
fix(viz): require auth + ADMIN role on /viz/auth/stream and /viz/ws

### DIFF
--- a/src/main/java/org/unlaxer/infra/volta/viz/VizRouter.java
+++ b/src/main/java/org/unlaxer/infra/volta/viz/VizRouter.java
@@ -139,9 +139,33 @@ public final class VizRouter {
             ctx.json(Map.of("flows", flows));
         });
 
-        // SAAS-016: SSE stream of login/logout auth events for Auth Monitor
+        // SAAS-016: SSE stream of login/logout auth events for Auth Monitor.
+        // 認証 + ADMIN ロールチェックを必須にする (#72)。
+        // /api/v1/admin/flows* と同等の保護レベル。
         if (authEventJedis != null) {
+            app.before("/viz/auth/stream", ctx -> {
+                var principal = authService.authenticate(ctx)
+                        .orElse(null);
+                if (principal == null) {
+                    HttpSupport.jsonError(ctx, 401, "AUTHENTICATION_REQUIRED", "Authentication required");
+                    ctx.skipRemainingHandlers();
+                    return;
+                }
+                policy.enforceMinRole(principal, "ADMIN");
+                ctx.attribute("principal", principal);
+            });
+
             app.sse("/viz/auth/stream", client -> {
+                // app.before で認証済みだが、upgrade に before が走らない
+                // 環境も想定して fail-closed で二重チェックする。
+                var principal = (AuthPrincipal) client.ctx().attribute("principal");
+                if (principal == null) {
+                    principal = authService.authenticate(client.ctx()).orElse(null);
+                }
+                if (principal == null) {
+                    client.close();
+                    return;
+                }
                 sseClients.add(client);
                 client.sendEvent("connected", "{\"status\":\"connected\"}");
                 client.onClose(() -> sseClients.remove(client));
@@ -160,9 +184,19 @@ public final class VizRouter {
         // tramli-viz VizDashboard protocol. On connect we emit `init-multi`
         // with all flow definitions, then forward each telemetry event as
         // `{ type: 'event', event: {...} }`.
+        // 認証 + ADMIN ロールチェックを必須にする (#72)。
+        // Javalin 6.7 では app.before は WS upgrade に走らないため、
+        // ws.onConnect で upgrade context を取り出して認証する。
         if (authEventJedis != null && vizFlowChannel != null && !vizFlowChannel.isBlank()) {
             app.ws("/viz/ws", ws -> {
                 ws.onConnect(ctx -> {
+                    var upgradeCtx = ctx.getUpgradeCtx$javalin();
+                    var principal = authService.authenticate(upgradeCtx).orElse(null);
+                    if (principal == null) {
+                        ctx.closeSession(4001, "AUTHENTICATION_REQUIRED");
+                        return;
+                    }
+                    policy.enforceMinRole(principal, "ADMIN");
                     wsClients.add(ctx);
                     try {
                         ctx.send(buildInitMultiMessage());

--- a/src/test/java/org/unlaxer/infra/volta/viz/VizRouterAuthTest.java
+++ b/src/test/java/org/unlaxer/infra/volta/viz/VizRouterAuthTest.java
@@ -1,0 +1,109 @@
+package org.unlaxer.infra.volta.viz;
+
+import io.javalin.Javalin;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.unlaxer.infra.volta.AppConfigTestFactory;
+import org.unlaxer.infra.volta.AuthService;
+import org.unlaxer.infra.volta.PolicyEngine;
+import redis.clients.jedis.JedisPooled;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Issue #72: /viz/auth/stream (SSE) と /viz/ws (WebSocket) が未認証接続を
+ * 拒否することを検証する。
+ *
+ * <p>VizRouter に app.before で authService.authenticate + policy.enforceMinRole
+ * (ADMIN) を追加し、未認証は 401 で拒否する。SSE は HTTP upgrade リクエストが
+ * before で拒否されるため 401 になる。
+ */
+class VizRouterAuthTest {
+
+    private Javalin app;
+
+    @AfterEach
+    void tearDown() {
+        if (app != null) {
+            app.stop();
+        }
+    }
+
+    @Test
+    void sseStreamRejectsUnauthenticatedConnection() throws Exception {
+        app = startVizRouterWithSse();
+        int port = app.port();
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + "/viz/auth/stream"))
+                .header("Accept", "text/event-stream")
+                .GET()
+                .build();
+        HttpResponse<String> res = client.send(req, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(401, res.statusCode(),
+                "未認証の SSE 接続は 401 で拒否されるべき");
+    }
+
+    @Test
+    void wsUpgradeRejectsUnauthenticatedConnection() throws Exception {
+        app = startVizRouterWithSseAndWs();
+        int port = app.port();
+
+        HttpClient client = HttpClient.newHttpClient();
+        // WebSocket upgrade 自体は HTTP レベルで成功するが、onConnect で
+        // 認証チェックに失敗すると closeSession(4001) で即座に閉じられる。
+        // この close を検知できれば認証チェックが効いている証拠。
+        var closed = new java.util.concurrent.CompletableFuture<Boolean>();
+        java.net.http.WebSocket ws = client.newWebSocketBuilder()
+                .connectTimeout(java.time.Duration.ofSeconds(3))
+                .buildAsync(URI.create("ws://localhost:" + port + "/viz/ws"),
+                        new java.net.http.WebSocket.Listener() {
+                            @Override
+                            public java.util.concurrent.CompletionStage<?> onClose(java.net.http.WebSocket webSocket,
+                                                                                    int statusCode, String reason) {
+                                closed.complete(statusCode == 4001);
+                                return null;
+                            }
+                        })
+                .get(5, java.util.concurrent.TimeUnit.SECONDS);
+        // close を待つ(5秒以内)
+        Boolean wasClosedWithAuthError = closed.get(5, java.util.concurrent.TimeUnit.SECONDS);
+        ws.abort();
+        if (!wasClosedWithAuthError) {
+            throw new AssertionError("未認証 WS 接続が 4001 で close されなかった — 認証チェックが効いていない");
+        }
+    }
+
+    private Javalin startVizRouterWithSse() {
+        return startVizRouter(false);
+    }
+
+    private Javalin startVizRouterWithSseAndWs() {
+        return startVizRouter(true);
+    }
+
+    private Javalin startVizRouter(boolean withWs) {
+        var config = AppConfigTestFactory.builder().build();
+        var authService = new AuthService(config, null, null, null);
+        var policy = PolicyEngine.defaultPolicy();
+        var objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        // JedisPooled は遅延接続。subscribe は別スレッドで試みるが接続失敗で
+        // WARNING ログを出すだけでテスト結果には影響しない。
+        JedisPooled jedis = new JedisPooled("localhost", 6379);
+        VizRouter router = new VizRouter(
+                null, authService, policy, objectMapper,
+                java.util.List.of(),
+                jedis, "volta:auth:events",
+                withWs ? "volta:viz:events" : null);
+        Javalin app = Javalin.create().start(0);
+        router.register(app);
+        return app;
+    }
+}


### PR DESCRIPTION
Closes #72

## What

`/viz/auth/stream` (SSE) と `/viz/ws` (WebSocket bridge) に認証なしで接続でき、全テナントのログイン/ログアウトイベント(`userId`, `email`, `sessionId` 含む)が匿名で配信されていた。`/api/v1/admin/flows*` と同等の保護レベル(`authService.authenticate` + `policy.enforceMinRole ADMIN`)を追加。

## Why

同じ `VizRouter` の `/api/v1/admin/flows*` は `policy.enforceMinRole(principal, "ADMIN")` で保護されているのに、`/viz/auth/stream` は保護なし。デフォルト設定(`REDIS_URL` 必須、`AUTH_EVENT_REDIS_CHANNEL` 未設定 → `volta:auth:events`)で有効化し、`/viz/` は MFA pending / tenant MFA required の両 before handler で exempt になっていたため、誰でも接続できた。

## How (最小・安全・可逆)

### SSE (`/viz/auth/stream`)
- `app.before("/viz/auth/stream", ...)` で `authService.authenticate` + `policy.enforceMinRole(principal, "ADMIN")` を追加し、未認証は 401 で拒否
- SSE ハンドラ内でも `client.ctx().attribute("principal")` が null なら `authService.authenticate` で再認証し、未認証は `client.close()` する fail-closed 二重チェック

### WS (`/viz/ws`)
- Javalin 6.7 では `app.before` は WebSocket upgrade リクエストに走らない(テストで確認)。そのため `ws.onConnect` で `ctx.getUpgradeCtx$javalin()` から `Context` を取り出し `authService.authenticate` + `policy.enforceMinRole` で認証
- 未認証は `ctx.closeSession(4001, "AUTHENTICATION_REQUIRED")` で即時切断

## 備考(判断)

- WS upgrade を HTTP レベル(401)で拒否できないため、upgrade 自体は成功し `onConnect` で close する形になった。これは WebSocket の仕様上の制約。クライアントは即座に close されるので実害はない
- `getUpgradeCtx$javalin()` は Javalin internal API だが、Javalin 6.7 では WS upgrade の `Context` を取る唯一の方法。Javalin 7 では `wsBeforeUpgrade` が提供されるので移行時に置換可能
- テナントスコープのイベント配信(接続者の `tenantId` でフィルタ)は issue の受け入れ条件の代替案として挙げられていたが、既存の `/api/v1/admin/flows*` と同等の ADMIN 制限を採用(最小修正)

## Verification

```
mvn test  →  Tests run: 276, Failures: 0, Errors: 0, Skipped: 0
```

- `sseStreamRejectsUnauthenticatedConnection`: 未認証 SSE 接続が 401
- `wsUpgradeRejectsUnauthenticatedConnection`: 未認証 WS 接続が 4001 close

revert は `git revert <merge-commit>` で可逆。