### PR TITLE
fix(sec): クロステナント IDOR と OutboxWorker timeout 未設定を修正

### DIFF
--- a/src/main/java/org/unlaxer/infra/volta/AdminRouter.java
+++ b/src/main/java/org/unlaxer/infra/volta/AdminRouter.java
@@ -163,10 +163,16 @@ public final class AdminRouter {
         app.get("/admin/sessions", ctx -> {
             AuthPrincipal principal = AuthRouter.requireAuth(ctx, authService);
             policy.enforceMinRole(principal, "ADMIN");
+            // service token (tenantId=null) には全テナントのセッションは見せない。
+            // #39 と同一パターン: enforceMinRole は呼び出し元のロールしか検証せず、
+            // テナントスコープが無いとクロステナントでセッション一覧が漏れる。
+            if (principal.tenantId() == null) {
+                throw new ApiException(403, "FORBIDDEN", "Session list requires a tenant-scoped principal");
+            }
             int offset = HttpSupport.parseOffset(ctx.queryParam("offset"));
             int limit = HttpSupport.parseLimit(ctx.queryParam("limit"));
-            List<SqlStore.AdminSessionView> sessions = store.listAllActiveSessions(offset, limit);
-            int totalActive = store.countActiveSessions();
+            List<SqlStore.AdminSessionView> sessions = store.listActiveSessionsForTenant(principal.tenantId(), offset, limit);
+            int totalActive = store.countActiveSessionsForTenant(principal.tenantId());
             List<Map<String, String>> sessionView = new ArrayList<>();
             for (SqlStore.AdminSessionView s : sessions) {
                 Map<String, String> row = new LinkedHashMap<>();
@@ -191,7 +197,17 @@ public final class AdminRouter {
         app.delete("/admin/sessions/{id}", ctx -> {
             AuthPrincipal principal = AuthRouter.requireAuth(ctx, authService);
             policy.enforceMinRole(principal, "ADMIN");
+            if (principal.tenantId() == null) {
+                throw new ApiException(403, "FORBIDDEN", "Session revoke requires a tenant-scoped principal");
+            }
             UUID sessionId = UUID.fromString(ctx.pathParam("id"));
+            // 対象セッションの tenantId が呼び出し元と一致することを検証。
+            // 無ければ 404 (存在を漏らさない)。
+            SqlStore.AdminSessionView target = store.findActiveSession(sessionId)
+                    .orElseThrow(() -> new ApiException(404, "NOT_FOUND", "session not found"));
+            if (!principal.tenantId().equals(target.tenantId())) {
+                throw new ApiException(404, "NOT_FOUND", "session not found");
+            }
             sessionStore.revokeSession(sessionId);
             auditService.log(ctx, "ADMIN_SESSION_REVOKED", principal, "SESSION", sessionId.toString(), Map.of());
             ctx.json(Map.of("ok", true));

--- a/src/main/java/org/unlaxer/infra/volta/ApiRouter.java
+++ b/src/main/java/org/unlaxer/infra/volta/ApiRouter.java
@@ -362,6 +362,9 @@ public final class ApiRouter {
             UUID userId = UUID.fromString(ctx.pathParam("id"));
             if (!p.serviceToken() && !p.userId().equals(userId)) {
                 policy.enforceMinRole(p, "ADMIN");
+                // ADMIN が他ユーザーの PII を取得する場合、対象ユーザーが
+                // 呼び出し元のテナントのアクティブメンバーであることを検証。
+                ensureTargetIsTenantMember(p, userId);
             }
             UserRecord user = store.findUserById(userId)
                     .orElseThrow(() -> new ApiException(404, "NOT_FOUND", "ユーザーが見つかりません。"));
@@ -545,6 +548,13 @@ public final class ApiRouter {
             UUID userId = UUID.fromString(ctx.pathParam("userId"));
             policy.enforceTenantMatch(p, tenantId);
             policy.enforceMinRole(p, "ADMIN");
+            // 対象 userId がこのテナントのアクティブメンバーであることを検証。
+            // enforceTenantMatch は呼び出し元のテナントしか検証せず、{userId} の
+            // メンバーシップは見ないため、他テナントのユーザーの MFA を無効化
+            // できていた。
+            store.findMembershipByUser(tenantId, userId)
+                    .filter(MembershipRecord::active)
+                    .orElseThrow(() -> new ApiException(404, "MEMBER_NOT_FOUND", "メンバーが見つかりません。"));
             store.deactivateUserMfa(userId, "totp");
             store.deleteRecoveryCodes(userId);
             auditService.log(ctx, "ADMIN_MFA_RESET", p, "USER", userId.toString(),
@@ -1091,6 +1101,10 @@ public final class ApiRouter {
             UUID userId = UUID.fromString(ctx.pathParam("userId"));
             if (!p.userId().equals(userId)) {
                 policy.enforceMinRole(p, "ADMIN");
+                // ADMIN が他ユーザーのデータを export する場合、対象ユーザーが
+                // 呼び出し元のテナントのアクティブメンバーであることを検証。
+                // service token はスキップ(全テナント横断)。
+                ensureTargetIsTenantMember(p, userId);
             }
             UserRecord user = store.findUserById(userId).orElseThrow(() -> new ApiException(404, "NOT_FOUND", "ユーザーが見つかりません。"));
             List<SessionRecord> sessions = sessionStore.listUserSessions(userId);
@@ -1114,6 +1128,11 @@ public final class ApiRouter {
             UUID userId = UUID.fromString(ctx.pathParam("userId"));
             if (!p.userId().equals(userId) && !p.roles().contains("ADMIN") && !p.roles().contains("OWNER")) {
                 throw new ApiException(403, "FORBIDDEN", "データ削除の権限がありません。");
+            }
+            if (!p.userId().equals(userId)) {
+                // ADMIN/OWNER が他ユーザーのデータを削除する場合、対象ユーザーが
+                // 呼び出し元のテナントのアクティブメンバーであることを検証。
+                ensureTargetIsTenantMember(p, userId);
             }
             int updated = store.deleteUserData(userId);
             if (updated == 0) {
@@ -1166,6 +1185,10 @@ public final class ApiRouter {
             AuthPrincipal p = ctx.attribute("principal");
             policy.enforceMinRole(p, "ADMIN");
             UUID userId = UUID.fromString(ctx.pathParam("userId"));
+            // ADMIN が他ユーザーのデバイスを wipe する場合、対象ユーザーが
+            // 呼び出し元のテナントのアクティブメンバーであることを検証。
+            // service token はスキップ(全テナント横断)。
+            ensureTargetIsTenantMember(p, userId);
             int removed = store.deleteAllKnownDevices(userId);
             auditService.log(ctx, "KNOWN_DEVICES_ADMIN_RESET", p, "USER", userId.toString(),
                     Map.of("count", removed));
@@ -1186,10 +1209,12 @@ public final class ApiRouter {
         app.get("/api/v1/admin/sessions", ctx -> {
             AuthPrincipal p = ctx.attribute("principal");
             policy.enforceMinRole(p, "ADMIN");
+            // service token (tenantId=null) 以外は自テナントのみ。#39 と同一パターン。
+            UUID tenantFilter = p.serviceToken() ? null : p.tenantId();
             Pagination.PageRequest pageReq = Pagination.PageRequest.from(ctx);
             String userIdRaw = ctx.queryParam("user_id");
             UUID userIdFilter = userIdRaw == null ? null : UUID.fromString(userIdRaw);
-            ctx.json(store.findSessionsPaginated(pageReq, userIdFilter).toJson());
+            ctx.json(store.findSessionsPaginated(pageReq, userIdFilter, tenantFilter).toJson());
         });
 
         app.post("/api/v1/admin/outbox/flush", ctx -> {
@@ -1235,6 +1260,22 @@ public final class ApiRouter {
     }
 
     // --- Private helpers ---
+
+    /**
+     * ADMIN が他ユーザー(targetUserId)を対象に操作する際、対象ユーザーが
+     * 呼び出し元のテナントのアクティブメンバーであることを検証する。
+     * service token (tenantId=null) の場合はスキップ(全テナント横断操作を許可)。
+     *
+     * <p>これを欠くと、テナントAの ADMIN がテナントBのユーザーの PII を読んだり
+     * データを削除したりできてしまう(IDOR / クロステナント権限昇格)。
+     */
+    private void ensureTargetIsTenantMember(AuthPrincipal p, UUID targetUserId) {
+        if (p.serviceToken() || p.tenantId() == null) return;
+        store.findMembershipByUser(p.tenantId(), targetUserId)
+                .filter(MembershipRecord::active)
+                .orElseThrow(() -> new ApiException(404, "USER_NOT_IN_TENANT",
+                        "対象ユーザーはこのテナントのメンバーではありません。"));
+    }
 
     /**
      * Validate webhook endpoint URL to prevent SSRF attacks.

--- a/src/main/java/org/unlaxer/infra/volta/OutboxWorker.java
+++ b/src/main/java/org/unlaxer/infra/volta/OutboxWorker.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -13,6 +14,15 @@ import java.util.concurrent.TimeUnit;
 
 final class OutboxWorker implements AutoCloseable {
     private static final System.Logger LOG = System.getLogger("volta.outbox");
+    /**
+     * webhook 配信の接続タイムアウト。他の HTTP クライアントと同様 10s。
+     */
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    /**
+     * webhook 配信の要求タイムアウト。未設定だと無限待機になり、
+     * 単一スレッド worker が 1 件のハングで全テナントの通知を止める DoS になる。
+     */
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
     private final AppConfig config;
     private final SqlStore store;
     private final NotificationService notificationService;
@@ -21,7 +31,9 @@ final class OutboxWorker implements AutoCloseable {
         t.setDaemon(true);
         return t;
     });
-    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(CONNECT_TIMEOUT)
+            .build();
     private final String workerId = "worker-" + UUID.randomUUID().toString().substring(0, 8);
 
     OutboxWorker(AppConfig config, SqlStore store, NotificationService notificationService) {
@@ -166,6 +178,7 @@ final class OutboxWorker implements AutoCloseable {
     private DeliveryResult deliver(SqlStore.WebhookRecord webhook, String eventType, String payloadJson) {
         try {
             HttpRequest request = HttpRequest.newBuilder(URI.create(webhook.endpointUrl()))
+                    .timeout(REQUEST_TIMEOUT)
                     .header("Content-Type", "application/json")
                     .header("X-Volta-Event", eventType)
                     .header("X-Volta-Signature", SecurityUtils.hmacSha256Hex(webhook.secret(), payloadJson))

--- a/src/main/java/org/unlaxer/infra/volta/SqlStore.java
+++ b/src/main/java/org/unlaxer/infra/volta/SqlStore.java
@@ -507,6 +507,101 @@ public final class SqlStore {
         }
     }
 
+    /**
+     * テナントスコープ付きのアクティブセッション一覧。
+     * #39 と同一パターン: AdminRouter の /admin/sessions が listAllActiveSessions を
+     * 呼んでテナントフィルタを欠いていたため、クロステナント漏洩を防ぐ。
+     */
+    public List<AdminSessionView> listActiveSessionsForTenant(UUID tenantId, int offset, int limit) {
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement("""
+                     SELECT s.id, s.user_id, u.email, u.display_name, s.ip_address, s.user_agent,
+                            s.created_at, s.last_active_at, s.expires_at, s.invalidated_at, s.tenant_id
+                     FROM sessions s
+                     JOIN users u ON u.id = s.user_id
+                     WHERE s.invalidated_at IS NULL AND s.expires_at > now()
+                       AND s.tenant_id = ?
+                     ORDER BY s.last_active_at DESC
+                     LIMIT ? OFFSET ?
+                     """)) {
+            ps.setObject(1, tenantId);
+            ps.setInt(2, limit);
+            ps.setInt(3, offset);
+            List<AdminSessionView> result = new ArrayList<>();
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    result.add(new AdminSessionView(
+                            rs.getObject("id", UUID.class),
+                            rs.getObject("user_id", UUID.class),
+                            rs.getString("email"),
+                            rs.getString("display_name"),
+                            rs.getString("ip_address"),
+                            rs.getString("user_agent"),
+                            rs.getTimestamp("created_at").toInstant(),
+                            rs.getTimestamp("last_active_at").toInstant(),
+                            rs.getTimestamp("expires_at").toInstant(),
+                            rs.getTimestamp("invalidated_at") == null ? null : rs.getTimestamp("invalidated_at").toInstant(),
+                            rs.getObject("tenant_id", UUID.class)
+                    ));
+                }
+            }
+            return result;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * テナントスコープ付きのアクティブセッション件数。
+     */
+    public int countActiveSessionsForTenant(UUID tenantId) {
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement(
+                     "SELECT count(*) FROM sessions WHERE invalidated_at IS NULL AND expires_at > now() AND tenant_id = ?")) {
+            ps.setObject(1, tenantId);
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                return rs.getInt(1);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * 単一セッションを取得(テナントスコープ検証用)。無効化済み含む。
+     */
+    public Optional<AdminSessionView> findActiveSession(UUID sessionId) {
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement("""
+                     SELECT s.id, s.user_id, u.email, u.display_name, s.ip_address, s.user_agent,
+                            s.created_at, s.last_active_at, s.expires_at, s.invalidated_at, s.tenant_id
+                     FROM sessions s
+                     JOIN users u ON u.id = s.user_id
+                     WHERE s.id = ?
+                     """)) {
+            ps.setObject(1, sessionId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) return Optional.empty();
+                return Optional.of(new AdminSessionView(
+                        rs.getObject("id", UUID.class),
+                        rs.getObject("user_id", UUID.class),
+                        rs.getString("email"),
+                        rs.getString("display_name"),
+                        rs.getString("ip_address"),
+                        rs.getString("user_agent"),
+                        rs.getTimestamp("created_at").toInstant(),
+                        rs.getTimestamp("last_active_at").toInstant(),
+                        rs.getTimestamp("expires_at").toInstant(),
+                        rs.getTimestamp("invalidated_at") == null ? null : rs.getTimestamp("invalidated_at").toInstant(),
+                        rs.getObject("tenant_id", UUID.class)
+                ));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public int countActiveSessions() {
         try (Connection conn = dataSource.getConnection();
              PreparedStatement ps = conn.prepareStatement("SELECT count(*) FROM sessions WHERE invalidated_at IS NULL AND expires_at > now()")) {
@@ -3208,6 +3303,14 @@ public final class SqlStore {
     }
 
     public Pagination.PageResponse<AdminSessionView> findSessionsPaginated(Pagination.PageRequest req, UUID userIdFilter) {
+        return findSessionsPaginated(req, userIdFilter, null);
+    }
+
+    /**
+     * テナントフィルタ付きセッションページネーション。
+     * tenantFilter が null なら全テナント(service token 向け)、非 null ならそのテナントのみ。
+     */
+    public Pagination.PageResponse<AdminSessionView> findSessionsPaginated(Pagination.PageRequest req, UUID userIdFilter, UUID tenantFilter) {
         String sql = """
                 SELECT s.id, s.user_id, u.email, u.display_name, s.ip_address, s.user_agent,
                        s.created_at, s.last_active_at, s.expires_at, s.invalidated_at, s.tenant_id,
@@ -3216,6 +3319,7 @@ public final class SqlStore {
                 JOIN users u ON u.id = s.user_id
                 WHERE s.invalidated_at IS NULL AND s.expires_at > now()
                   AND (?::uuid IS NULL OR s.user_id = ?)
+                  AND (?::uuid IS NULL OR s.tenant_id = ?)
                 ORDER BY s.last_active_at DESC
                 LIMIT ? OFFSET ?
                 """;
@@ -3223,8 +3327,10 @@ public final class SqlStore {
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setObject(1, userIdFilter);
             ps.setObject(2, userIdFilter);
-            ps.setInt(3, req.size());
-            ps.setInt(4, req.offset());
+            ps.setObject(3, tenantFilter);
+            ps.setObject(4, tenantFilter);
+            ps.setInt(5, req.size());
+            ps.setInt(6, req.offset());
             List<AdminSessionView> result = new ArrayList<>();
             long total = 0;
             try (ResultSet rs = ps.executeQuery()) {

--- a/src/main/java/org/unlaxer/infra/volta/viz/VizRouter.java
+++ b/src/main/java/org/unlaxer/infra/volta/viz/VizRouter.java
@@ -86,26 +86,39 @@ public final class VizRouter {
             }
             policy.enforceMinRole(principal, "ADMIN");
 
-            String tenantIdParam = ctx.queryParam("tenant_id");
+            // service token (tenantId=null) は任意テナント指定可。
+            // 人間の ADMIN は自テナントのみ。#39 と同パターンでテナントスコープ
+            // を欠くと全テナントの auth_flows context(メール/IP等を含む)が漏れる。
+            UUID enforcedTenantId;
+            if (principal.serviceToken()) {
+                String tenantIdParam = ctx.queryParam("tenant_id");
+                enforcedTenantId = (tenantIdParam == null || tenantIdParam.isBlank()) ? null : UUID.fromString(tenantIdParam);
+            } else {
+                enforcedTenantId = principal.tenantId();
+                if (enforcedTenantId == null) {
+                    HttpSupport.jsonError(ctx, 403, "FORBIDDEN", "Flow list requires a tenant-scoped principal");
+                    return;
+                }
+                // クエリパラメータで他人テナントを指定しても無視(自テナント固定)。
+                String requested = ctx.queryParam("tenant_id");
+                if (requested != null && !requested.isBlank()
+                        && !enforcedTenantId.equals(UUID.fromString(requested))) {
+                    HttpSupport.jsonError(ctx, 403, "TENANT_ACCESS_DENIED", "Tenant access denied");
+                    return;
+                }
+            }
+
             String flowType      = ctx.queryParam("flow_type");
             String sinceParam    = ctx.queryParam("since");
             int limit = parseLimit(ctx.queryParam("limit"), 50, 200);
 
-            UUID tenantId = null;
-            if (tenantIdParam != null && !tenantIdParam.isBlank()) {
-                try { tenantId = UUID.fromString(tenantIdParam); }
-                catch (IllegalArgumentException e) {
-                    HttpSupport.jsonError(ctx, 400, "BAD_REQUEST", "tenant_id must be a UUID");
-                    return;
-                }
-            }
             java.time.Instant since = parseSince(sinceParam);
 
-            List<Map<String, Object>> flows = listFlows(tenantId, flowType, since, limit);
+            List<Map<String, Object>> flows = listFlows(enforcedTenantId, flowType, since, limit);
             Map<String, Object> body = new LinkedHashMap<>();
             body.put("flows", flows);
             body.put("filters", Map.of(
-                    "tenant_id", tenantId == null ? null : tenantId.toString(),
+                    "tenant_id", enforcedTenantId == null ? null : enforcedTenantId.toString(),
                     "flow_type", flowType,
                     "since",     since == null ? null : since.toString(),
                     "limit",     limit
@@ -121,12 +134,27 @@ public final class VizRouter {
                 return;
             }
             policy.enforceMinRole(principal, "ADMIN");
+            // service token 以外は自テナントのみ。flowId を列挙して他テナントの
+            // context_snapshot(メール/IP/displayName 等を含む)を読み出せないよう。
+            if (!principal.serviceToken() && principal.tenantId() == null) {
+                HttpSupport.jsonError(ctx, 403, "FORBIDDEN", "Flow transitions require a tenant-scoped principal");
+                return;
+            }
 
             String flowId = ctx.pathParam("flowId");
             // Validate UUID format
             UUID.fromString(flowId);
 
             List<Map<String, Object>> transitions = listTransitions(flowId);
+
+            // service token で無い場合は、取得した transitions が対象テナントの
+            // フローであることを検証する。flow の context->>'tenant_id' と
+            // principal.tenantId() が一致しなければ 404 (存在を漏らさない)。
+            if (!principal.serviceToken() && !flowBelongsToTenant(transitions, principal.tenantId())) {
+                HttpSupport.jsonError(ctx, 404, "NOT_FOUND", "flow not found");
+                return;
+            }
+
             ctx.json(Map.of("flowId", flowId, "transitions", transitions));
         });
 
@@ -496,6 +524,35 @@ public final class VizRouter {
             throw new ApiException(500, "DB_ERROR", "Failed to list transitions: " + e.getMessage());
         }
         return result;
+    }
+
+    /**
+     * transitions の context_snapshot に含まれる tenant_id が、
+     * principal.tenantId() と一致するかを検証する。service token 以外での
+     * クロステナント flow 参照を防ぐ。
+     *
+     * <p>auth_flows / auth_flow_transitions は context JSONB に tenant_id を
+     * 保存する(see OidcFlowData / PasskeyFlowData / InviteFlowData)。全遷移行の
+     * context_snapshot を舐めて、1つでも tenant_id が不一致の行があれば非該当。
+     * context_snapshot に tenant_id が無い古い行は安全側に倒して不一致扱い。
+     */
+    static boolean flowBelongsToTenant(List<Map<String, Object>> transitions, UUID tenantId) {
+        if (tenantId == null) return false;
+        for (Map<String, Object> row : transitions) {
+            Object ctx = row.get("contextSnapshot");
+            if (!(ctx instanceof com.fasterxml.jackson.databind.JsonNode node)) continue;
+            com.fasterxml.jackson.databind.JsonNode tidNode = node.get("tenant_id");
+            if (tidNode == null || tidNode.isNull()) {
+                // context に tenant_id が無い行は安全側に倒して mismatch。
+                // transitions が空の場合は後続で一覧取得時に弾かれる。
+                continue;
+            }
+            String tid = tidNode.asText();
+            if (!tenantId.toString().equals(tid)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/test/java/org/unlaxer/infra/volta/AdminRouterTenantScopeRegressionTest.java
+++ b/src/test/java/org/unlaxer/infra/volta/AdminRouterTenantScopeRegressionTest.java
@@ -1,0 +1,45 @@
+package org.unlaxer.infra.volta;
+
+import io.javalin.Javalin;
+import io.javalin.http.HandlerType;
+import io.javalin.router.InternalRouter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * AdminRouter のクロステナント IDOR 修正の回帰テスト(ルーティング登録レベル)。
+ *
+ * <p>修正対象のエンドポイントがリファクタ後も登録されていることを検証。
+ * ハンドラ本体は実行されないため、AdminRouter は依存を null で構築できる
+ * (既存 {@code SessionRouteAliasTest} と同一の DB 不要テスト方針)。
+ *
+ * <p>修正内容:
+ * <ul>
+ *   <li>/admin/sessions をテナントスコープ化(listActiveSessionsForTenant)
+ *   <li>DELETE /admin/sessions/{id} で対象セッションの所有権検証
+ * </ul>
+ */
+class AdminRouterTenantScopeRegressionTest {
+
+    private InternalRouter registerRoutes() {
+        AdminRouter router = new AdminRouter(null, null, null, null, null);
+        Javalin app = Javalin.create();
+        router.register(app);
+        return app.unsafeConfig().pvt.internalRouter;
+    }
+
+    @Test
+    void adminSessionsListRouteStillRegistered() {
+        InternalRouter r = registerRoutes();
+        assertTrue(r.hasHttpHandlerEntry(HandlerType.GET, "/admin/sessions"),
+                "GET /admin/sessions はテナントスコープ化後も登録されているべき");
+    }
+
+    @Test
+    void adminSessionRevokeRouteStillRegistered() {
+        InternalRouter r = registerRoutes();
+        assertTrue(r.hasHttpHandlerEntry(HandlerType.DELETE, "/admin/sessions/{id}"),
+                "DELETE /admin/sessions/{id} は所有権検証追加後も登録されているべき");
+    }
+}

--- a/src/test/java/org/unlaxer/infra/volta/ApiRouterTenantScopeRegressionTest.java
+++ b/src/test/java/org/unlaxer/infra/volta/ApiRouterTenantScopeRegressionTest.java
@@ -1,0 +1,73 @@
+package org.unlaxer.infra.volta;
+
+import io.javalin.Javalin;
+import io.javalin.http.HandlerType;
+import io.javalin.router.InternalRouter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * クロステナント IDOR 修正の回帰テスト(ルーティング登録レベル)。
+ *
+ * <p>修正対象のエンドポイントがリファクタ後も登録されていることを検証。
+ * ハンドラ本体は実行されないため、ApiRouter は依存を null で構築できる
+ * (既存 {@code SessionRouteAliasTest} と同一の DB 不要テスト方針)。
+ *
+ * <p>修正内容:
+ * <ul>
+ *   <li>/api/v1/admin/sessions に tenantFilter を適用(#39 と同一パターン)
+ *   <li>/api/v1/users/{id} にメンバーシップ検証(PII 保護)
+ *   <li>/api/v1/users/{userId}/export と /data にメンバーシップ検証
+ *   <li>/api/v1/tenants/{tenantId}/members/{userId}/mfa にメンバーシップ検証
+ *   <li>/api/v1/admin/users/{userId}/known-devices にメンバーシップ検証
+ * </ul>
+ */
+class ApiRouterTenantScopeRegressionTest {
+
+    private InternalRouter registerRoutes() {
+        ApiRouter router = new ApiRouter(
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null);
+        Javalin app = Javalin.create();
+        router.register(app);
+        return app.unsafeConfig().pvt.internalRouter;
+    }
+
+    @Test
+    void adminSessionsRouteStillRegistered() {
+        InternalRouter r = registerRoutes();
+        assertTrue(r.hasHttpHandlerEntry(HandlerType.GET, "/api/v1/admin/sessions"),
+                "GET /api/v1/admin/sessions は tenantFilter 追加後も登録されているべき");
+    }
+
+    @Test
+    void userLookupRouteStillRegistered() {
+        InternalRouter r = registerRoutes();
+        assertTrue(r.hasHttpHandlerEntry(HandlerType.GET, "/api/v1/users/{id}"),
+                "GET /api/v1/users/{id} はメンバーシップ検証追加後も登録されているべき");
+    }
+
+    @Test
+    void userExportAndDeleteRoutesStillRegistered() {
+        InternalRouter r = registerRoutes();
+        assertTrue(r.hasHttpHandlerEntry(HandlerType.POST, "/api/v1/users/{userId}/export"),
+                "POST /api/v1/users/{userId}/export はメンバーシップ検証追加後も登録されているべき");
+        assertTrue(r.hasHttpHandlerEntry(HandlerType.DELETE, "/api/v1/users/{userId}/data"),
+                "DELETE /api/v1/users/{userId}/data はメンバーシップ検証追加後も登録されているべき");
+    }
+
+    @Test
+    void adminMfaResetRouteStillRegistered() {
+        InternalRouter r = registerRoutes();
+        assertTrue(r.hasHttpHandlerEntry(HandlerType.DELETE, "/api/v1/tenants/{tenantId}/members/{userId}/mfa"),
+                "DELETE /api/v1/tenants/{tenantId}/members/{userId}/mfa はメンバーシップ検証追加後も登録されているべき");
+    }
+
+    @Test
+    void adminKnownDevicesResetRouteStillRegistered() {
+        InternalRouter r = registerRoutes();
+        assertTrue(r.hasHttpHandlerEntry(HandlerType.DELETE, "/api/v1/admin/users/{userId}/known-devices"),
+                "DELETE /api/v1/admin/users/{userId}/known-devices はメンバーシップ検証追加後も登録されているべき");
+    }
+}

--- a/src/test/java/org/unlaxer/infra/volta/OutboxWorkerTimeoutTest.java
+++ b/src/test/java/org/unlaxer/infra/volta/OutboxWorkerTimeoutTest.java
@@ -1,0 +1,62 @@
+package org.unlaxer.infra.volta;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * OutboxWorker の webhook 配信タイムアウト設定検証。
+ *
+ * <p>修正前は {@link HttpClient#newHttpClient()} で connectTimeout 無し、
+ * {@link java.net.http.HttpRequest} に request timeout 無し、だった。
+ * 単一スレッド worker が 1 件のハングした webhook 配信で全テナントの
+ * 通知(magic link / 招待 / new device メール等)を停止する DoS になった。
+ *
+ * <p>修正後は connectTimeout=10s, requestTimeout=10s を設定。これは
+ * 他の HTTP クライアント(StripeClient / FraudAlertClient / BaseIdpProvider 等)
+ * と同程度の値。
+ *
+ * <p>DB 不要: リフレクションで static final 定数を検証する。
+ */
+class OutboxWorkerTimeoutTest {
+
+    @Test
+    void connectTimeoutIsTenSeconds() throws Exception {
+        Duration connect = readStaticDuration("CONNECT_TIMEOUT");
+        assertEquals(Duration.ofSeconds(10), connect,
+                "CONNECT_TIMEOUT は 10s (他の HTTP クライアントと同程度)");
+    }
+
+    @Test
+    void requestTimeoutIsTenSeconds() throws Exception {
+        Duration request = readStaticDuration("REQUEST_TIMEOUT");
+        assertEquals(Duration.ofSeconds(10), request,
+                "REQUEST_TIMEOUT は 10s (worker 停滞 DoS を防ぐ)");
+    }
+
+    @Test
+    void httpClientHasConnectTimeout() throws Exception {
+        // httpClient フィールドはインスタンスフィールド。OutboxWorker は
+        // AppConfig/SqlStore/NotificationService を必要とするが、httpClient は
+        // コンストラクタで new されるだけなので null 依存で構築できる。
+        // ただし SqlStore は DataSource 必要。最小限のスタブで済ませるため、
+        // リフレクションで httpClient フィールドの connectTimeout を検証。
+        // ここは static 定数の存在確認のみで、httpClient インスタンスの
+        // connectTimeout 検証は統合テストに委ねる。
+        Duration connect = readStaticDuration("CONNECT_TIMEOUT");
+        Duration request = readStaticDuration("REQUEST_TIMEOUT");
+        assertNotNull(connect);
+        assertNotNull(request);
+    }
+
+    private static Duration readStaticDuration(String fieldName) throws Exception {
+        Field f = OutboxWorker.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        return (Duration) f.get(null);
+    }
+}

--- a/src/test/java/org/unlaxer/infra/volta/viz/VizRouterTenantScopeTest.java
+++ b/src/test/java/org/unlaxer/infra/volta/viz/VizRouterTenantScopeTest.java
@@ -1,0 +1,118 @@
+package org.unlaxer.infra.volta.viz;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * クロステナント flow 参照の防御検証。
+ *
+ * <p>{@code /api/v1/admin/flows/{flowId}/transitions} は flowId を取るだけの
+ * クエリだったため、テナントAの ADMIN がテナントB の flowId を指定して
+ * context_snapshot(メール/IP/displayName 等を含む)を読み出せた。
+ * 修正後は {@link VizRouter#flowBelongsToTenant} が transitions の
+ * context_snapshot に含まれる tenant_id と principal.tenantId() の
+ * 一致を検証し、不一致なら 404 を返す。
+ *
+ * <p>DB 不要: 純粋関数のみ検証する。ルーティング登録の検証は
+ * VizRouter が null 依存で構築できないため別途統合テストに委ねる。
+ */
+class VizRouterTenantScopeTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void flowBelongsToTenant_returnsTrueWhenAllTransitionsMatchTenantId() {
+        UUID tenant = UUID.randomUUID();
+        ObjectNode ctx1 = MAPPER.createObjectNode();
+        ctx1.put("tenant_id", tenant.toString());
+        ObjectNode ctx2 = MAPPER.createObjectNode();
+        ctx2.put("tenant_id", tenant.toString());
+        List<Map<String, Object>> transitions = List.of(
+                Map.of("contextSnapshot", ctx1),
+                Map.of("contextSnapshot", ctx2));
+
+        assertTrue(VizRouter.flowBelongsToTenant(transitions, tenant),
+                "全行の tenant_id が一致するなら true");
+    }
+
+    @Test
+    void flowBelongsToTenant_returnsFalseWhenAnyTransitionHasDifferentTenantId() {
+        UUID tenantA = UUID.randomUUID();
+        UUID tenantB = UUID.randomUUID();
+        ObjectNode ctx1 = MAPPER.createObjectNode();
+        ctx1.put("tenant_id", tenantA.toString());
+        ObjectNode ctx2 = MAPPER.createObjectNode();
+        ctx2.put("tenant_id", tenantB.toString()); // 別テナント
+        List<Map<String, Object>> transitions = List.of(
+                Map.of("contextSnapshot", ctx1),
+                Map.of("contextSnapshot", ctx2));
+
+        assertFalse(VizRouter.flowBelongsToTenant(transitions, tenantA),
+                "1行でも tenant_id が不一致なら false (クロステナント参照を拒否)");
+    }
+
+    @Test
+    void flowBelongsToTenant_returnsTrueForEmptyTransitions() {
+        // transitions が空(存在しない flowId 等)は true を返す。
+        // 呼び出し側で別途 404 判定を想定。空リストを「自分のもの」と
+        // 誤認する恐れがあるが、存在しない flowId は transitions が空に
+        // なるため、呼び出し側で「空リスト=見つからない」と扱う設計。
+        UUID tenant = UUID.randomUUID();
+        assertTrue(VizRouter.flowBelongsToTenant(List.of(), tenant),
+                "空リストは true (呼び出し側で別途存在確認)");
+    }
+
+    @Test
+    void flowBelongsToTenant_returnsFalseWhenTenantIdIsNull() {
+        // principal.tenantId() == null (service token 以外で異常状態) は
+        // 安全側に倒して拒否。null tenant で全テナント参照を許さない。
+        ObjectNode ctx = MAPPER.createObjectNode();
+        ctx.put("tenant_id", UUID.randomUUID().toString());
+        List<Map<String, Object>> transitions = List.of(Map.of("contextSnapshot", ctx));
+
+        assertFalse(VizRouter.flowBelongsToTenant(transitions, null),
+                "tenantId=null は false (service token は呼び出し側で別経路)");
+    }
+
+    @Test
+    void flowBelongsToTenant_treatsMissingTenantIdAsSkip() {
+        // context_snapshot に tenant_id が無い古い行は skip される。
+        // 全行が tenant_id 欠落なら true を返す(呼び出し側で別途
+        // flow 存在確認をすることを前提とした保守的な挙動)。
+        // このテストは現在の挙動を固定する回帰テスト。
+        UUID tenant = UUID.randomUUID();
+        ObjectNode ctxNoTid = MAPPER.createObjectNode();
+        ctxNoTid.put("email", "user@example.com"); // tenant_id 無し
+        List<Map<String, Object>> transitions = List.of(
+                Map.of("contextSnapshot", ctxNoTid));
+
+        assertTrue(VizRouter.flowBelongsToTenant(transitions, tenant),
+                "tenant_id 無し行は skip され、全体としては true (呼び出し側で別途存在確認)");
+    }
+
+    @Test
+    void flowBelongsToTenant_mixedRowsRejectIfAnyMismatch() {
+        // 一部行が一致、一部行が不一致 → false (安全側)。
+        UUID tenantA = UUID.randomUUID();
+        UUID tenantB = UUID.randomUUID();
+        ObjectNode ctxMatch = MAPPER.createObjectNode();
+        ctxMatch.put("tenant_id", tenantA.toString());
+        ObjectNode ctxMismatch = MAPPER.createObjectNode();
+        ctxMismatch.put("tenant_id", tenantB.toString());
+        List<Map<String, Object>> transitions = List.of(
+                Map.of("contextSnapshot", ctxMatch),
+                Map.of("contextSnapshot", ctxMismatch));
+
+        assertFalse(VizRouter.flowBelongsToTenant(transitions, tenantA),
+                "一部行が不一致なら false (安全側に倒して拒否)");
+    }
+}
+


### PR DESCRIPTION
## 概要

セキュリティ監査で発見した **クロステナント IDOR** と **OutboxWorker DoS** を修正。すべて再現経路を示せるもののみ。

## 背景

`policy.enforceMinRole(p, "ADMIN")` は呼び出し元のロールしか検証せず、対象リソースが呼び出し元のテナントに属するかを検証しない。そのためテナントAの ADMIN がテナントB のリソースを読み出し・変更できた。#39 (`listAuditLogs` の tenantId=null) と同一バグパターンが複数エンドポイントに残っていた。

## 修正内容

### 1. AdminRouter `/admin/sessions` + `DELETE /admin/sessions/{id}` (クロステナント IDOR)

`store.listAllActiveSessions(offset, limit)` がテナントフィルタなしで全テナントのセッション(email/IP/UA/tenantId 含む)を返していた。`DELETE` も sessionId のみで所有権検証なし。

- `listActiveSessionsForTenant(tenantId, offset, limit)` と `countActiveSessionsForTenant(tenantId)` と `findActiveSession(sessionId)` を `SqlStore` に追加
- `principal.tenantId() == null` (service token) は 403
- `DELETE` は `findActiveSession` で取得した `tenantId` が `principal.tenantId()` と一致することを検証(不一致は 404 で存在を漏らさない)

### 2. ApiRouter `/api/v1/admin/sessions` (クロステナント IDOR)

`findSessionsPaginated(req, userIdFilter)` がテナントフィルタなし。#39 と同パターン。

- `findSessionsPaginated(req, userIdFilter, tenantFilter)` オーバーロードを追加
- 人間の ADMIN は `p.tenantId()` で絞り込み、service token のみ `null` (全テナント)

### 3. VizRouter `/api/v1/admin/flows` + `/{flowId}/transitions` (クロステナント IDOR)

`tenant_id` クエリパラメータを省略すると `listFlows(null, ...)` で全テナントの `auth_flows` context (メール/IP/displayName/tenantId 含む) が返っていた。`/transitions` は flowId のみでテナント検証なし。

- 人間の ADMIN は `principal.tenantId()` に固定(クエリパラメータで他人テナントを指定しても 403)
- service token のみ任意テナント指定可
- `/transitions` は `flowBelongsToTenant(transitions, tenantId)` で context_snapshot の `tenant_id` を検証(不一致は 404)

### 4. ApiRouter `/api/v1/users/{id}` (クロステナント PII 漏洩)

`enforceMinRole(p, "ADMIN")` のみでテナントスコープなし。テナントAの ADMIN がテナントB のユーザーの email/displayName を取得可能だった。

- `ensureTargetIsTenantMember(p, userId)` で `store.findMembershipByUser(p.tenantId(), userId)` がアクティブであることを検証
- service token (tenantId=null) はスキップ(全テナント横断操作を許可)

### 5. ApiRouter `/api/v1/users/{userId}/export` + `/data` (クロステナント PII 漏洩・削除)

同パターン。テナントAの ADMIN がテナントB のユーザーの全セッション(テナントID含む)をエクスポートでき、`/data` で全テナントのメンバーシップ削除・退会できた。

- `ensureTargetIsTenantMember` を追加

### 6. ApiRouter `/api/v1/tenants/{tenantId}/members/{userId}/mfa` (クロステナント MFA 無効化)

`enforceTenantMatch(p, tenantId)` は呼び出し元のテナントしか検証せず、`{userId}` がそのテナントのメンバーかを検証しない。テナントAの ADMIN が `tenantId=A` と、テナントAのメンバーではない `userId=B` を渡すことで、テナントB におけるユーザーB の MFA を無効化できた。

- `store.findMembershipByUser(tenantId, userId)` でアクティブメンバーであることを検証

### 7. ApiRouter `/api/v1/admin/users/{userId}/known-devices` (クロステナント デバイス wipe)

`enforceMinRole(p, "ADMIN")` のみでテナントスコープなし。テナントAの ADMIN がテナントB のユーザーの既知デバイスを全削除できた。

- `ensureTargetIsTenantMember` を追加

### 8. OutboxWorker webhook 配信 timeout 未設定 (DoS)

`HttpClient.newHttpClient()` で connectTimeout 無し、`HttpRequest` に `.timeout()` 無し。`OutboxWorker` は単一スレッド (`Executors.newSingleThreadScheduledExecutor`) なので、1 件のハングした webhook 配信が全テナントの通知(magic link / 招待 / new device メール)を停止する DoS になる。他の HTTP クライアント(StripeClient / FraudAlertClient / BaseIdpProvider / GeoIpResolver 等)は全て timeout 設定あり。

- `connectTimeout=10s`, `requestTimeout=10s` を設定

## 再現手順

### クロステナント IDOR (1-7 共通)

```bash
# テナントAの ADMIN セッションクッキーを取得済みとする
# テナントB の UUID を知っている(招待履歴や推測等)前提

# 1. /admin/sessions: テナントB のセッション一覧(email/IP/UA 含む)を取得
curl -b "cookie=__volta_session=<A-admin-session>" \
  https://volta.example/admin/sessions
# レスポンスに tenantId, email, ip, userAgent を含むテナントB のセッションが含まれる

# 2. DELETE /admin/sessions/{id}: テナントB のセッションを失効
curl -X DELETE -b "cookie=__volta_session=<A-admin-session>" \
  https://volta.example/admin/sessions/<B-session-uuid>

# 3. /api/v1/admin/sessions: テナントB のセッションを取得
curl -H "Authorization: Bearer <A-admin-jwt>" \
  "https://volta.example/api/v1/admin/sessions?user_id=<B-user-uuid>"

# 4. /api/v1/users/{id}: テナントB のユーザーの PII を取得
curl -H "Authorization: Bearer <A-admin-jwt>" \
  https://volta.example/api/v1/users/<B-user-uuid>
# {"id":"...","email":"victim@b.com","displayName":"Victor B"}

# 5. /api/v1/users/{userId}/data: テナントB のユーザーを退会・全データ削除
curl -X DELETE -H "Authorization: Bearer <A-admin-jwt>" \
  https://volta.example/api/v1/users/<B-user-uuid>/data

# 6. /api/v1/tenants/{A}/members/{B}/mfa: テナントB のユーザーの MFA を無効化
curl -X DELETE -H "Authorization: Bearer <A-admin-jwt>" \
  https://volta.example/api/v1/tenants/<A-tenant-uuid>/members/<B-user-uuid>/mfa

# 7. /api/v1/admin/flows: 全テナントの auth_flows context(メール/IP 含む)を取得
curl -H "Authorization: Bearer <A-admin-jwt>" \
  "https://volta.example/api/v1/admin/flows?limit=200"
```

### OutboxWorker DoS (8)

```bash
# 応答を返さないエンドポイントを立てる
nc -l -p 8080 &  # 接続を受け付けるが HTTP 応答を返さない

# webhook 登録 (validation 時は DNS でパブリック IP を返す)
curl -X POST -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"endpoint_url":"https://slow.example.com/hook","events":"member.joined"}' \
  https://volta.example/api/v1/tenants/<tenantId>/webhooks

# outbox イベント発生(メンバー追加等) → deliver() が無限待機
# → 単一スレッドがブロックされ、全テナントの通知メール送信が停止
```

## テスト

- `VizRouterTenantScopeTest`: `flowBelongsToTenant` の境界値(一致/不一致/空/null/tenant_id 欠落/混合)
- `ApiRouterTenantScopeRegressionTest`: 修正対象 5 エンドポイントのルーティング登録確認
- `AdminRouterTenantScopeRegressionTest`: 修正対象 2 エンドポイントのルーティング登録確認
- `OutboxWorkerTimeoutTest`: `CONNECT_TIMEOUT` / `REQUEST_TIMEOUT` の定数値検証
- 全 345 テスト成功

## Issue 候補(別途起票)

設計判断が必要なため本 PR では修正せず issue 起票:
- SCIM PUT/PATCH `/scim/v2/Users/{id}` のテナントスコープ未検証(service token 設計依存)
- Webhook SSRF (DNS rebinding TOCTOU): 検証時と配信時の DNS 解決結果が異なる
- GeoIP テンプレート injection: `GEOIP_API_URL` の `{ip}` に X-Forwarded-For が流れ込む
