### PR TITLE
MCP のセッションを回収する。3.6 時間で 2GB まで育っていた

### DIFF
--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -5,6 +5,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
+import { startSessionReaper } from './session-reaper.mjs';
 
 function log(...a) {
   process.stderr.write('[auth-mcp] ' + a.map((x) => typeof x === 'string' ? x : JSON.stringify(x)).join(' ') + '\n');
@@ -462,7 +463,24 @@ function buildSpec() {
 // --- HTTP server (Streamable HTTP) ---
 
 async function serveHttp(port) {
+  // sessionId -> { transport, lastSeen, open }
+  // **セッションを一生捨てない**問題があった。Streamable HTTP は要求ごとの往復なので、
+  // クライアントが黙って居なくなっても onclose が来ず、transport と McpServer が
+  // 丸ごと残る。実測(2026-08-30): 3.6 時間で 2,043MB(570MB/時)まで育った。
   const transports = new Map();
+
+  startSessionReaper({
+    sessions: transports,
+    close: (id) => {
+      const e = transports.get(id);
+      transports.delete(id);
+      e?.transport?.close?.().catch?.(() => {});
+    },
+    idleMs: Number(process.env.SESSION_IDLE_MS || 10 * 60_000),
+    sweepMs: Number(process.env.SESSION_SWEEP_MS || 30_000),
+    maxSessions: Number(process.env.MAX_SESSIONS || 32),
+    onReap: (n) => log('sessions reaped', { count: n, remaining: transports.size }),
+  });
   const httpServer = http.createServer(async (req, res) => {
     res.setHeader('content-encoding', 'identity');
     const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
@@ -477,13 +495,18 @@ async function serveHttp(port) {
       }
       const sid = req.headers['mcp-session-id'];
       if (sid && transports.has(sid)) {
-        return await transports.get(sid).handleRequest(req, res);
+        const entry = transports.get(sid);
+        entry.lastSeen = Date.now();
+        // 開いたままの stream(SSE)も「生きている」。要求が来ないだけで放置ではない
+        entry.open = (entry.open ?? 0) + 1;
+        res.on('close', () => { entry.open = Math.max(0, (entry.open ?? 1) - 1); entry.lastSeen = Date.now(); });
+        return await entry.transport.handleRequest(req, res);
       }
       if (req.method === 'POST' && !sid) {
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
           enableJsonResponse: true,
-          onsessioninitialized: (id) => { transports.set(id, transport); log('session open', { sid: id }); },
+          onsessioninitialized: (id) => { transports.set(id, { transport, lastSeen: Date.now(), open: 0 }); log('session open', { sid: id }); },
           onsessionclosed: (id) => { transports.delete(id); log('session closed', { sid: id }); },
         });
         const server = createServer();

--- a/mcp/session-reaper.mjs
+++ b/mcp/session-reaper.mjs
@@ -1,0 +1,101 @@
+// ホストセッションの回収。
+//
+// **なぜ要るか**: Streamable HTTP は要求ごとの往復で、クライアントが黙って
+// 居なくなっても気づけない。プロセスが落ちた・ネットワークが切れた・agent が
+// 再起動した場合、DELETE も close も来ないので `server.onclose` は永遠に来ない。
+//
+// 1 セッションはバックエンドごとに接続を 1 本ずつ持つ（v2 の双方向対応のため）。
+// つまり放置セッションのコストは **バックエンド数 × 放置数** の接続と FD になる。
+//
+// 実際に起きたこと（2026-08-30）:
+//   1.8 時間で FD 41,929 / ESTABLISHED 75,000 まで育ち、/proc/net/tcp が 7 万行に。
+//   それを毎秒読む監視ツールが 290MB/分 で膨らみ、箱がメモリ枯渇。
+//   OOM が 26 回発動して systemd や sshd まで巻き添えになり、SSH も HTTP も届かなくなった。
+//
+// 判断を純粋な関数に切り出してあるのは、**時計もタイマーも無しで試験するため**。
+
+/**
+ * 閉じるべきセッションを選ぶ。**選ぶだけで閉じない**（呼ぶ側が閉じる）。
+ *
+ * @param {Map<string,{lastSeen:number,open?:number}>} sessions sid -> 最終アクセス時刻と開いている接続数
+ * @param {{now:number, idleMs:number, maxSessions:number}} opt
+ * @returns {string[]} 閉じるべき sid。**古い順**
+ */
+export function pickExpired(sessions, { now, idleMs, maxSessions }) {
+  const entries = [...sessions.entries()].map(([sid, s]) => [sid, Number(s?.lastSeen) || 0, Number(s?.open) || 0]);
+  const doomed = new Set();
+
+  // 1) 放置されたもの。idleMs が 0 以下なら無効（時間では切らない）
+  //
+  // ★ **開いたままの接続(SSE)を持つセッションは切らない。**
+  //   GET /mcp は接続を張りっぱなしにするので、その間は新しい要求が来ず
+  //   lastSeen が古いままになる。それを「放置」と読むと、**繋がっている
+  //   クライアントを切って** 404 を返し、再接続 → 新セッションを作らせる。
+  //   実測(2026-08-30): 20 分で 292 セッションを回収し、その直後に GET /mcp の
+  //   404 が続いていた。積み上がりの一部は回収側が作っていた。
+  if (idleMs > 0) {
+    for (const [sid, last, open] of entries) if (open === 0 && now - last > idleMs) doomed.add(sid);
+  }
+
+  // 2) 数の上限。**受け付けを止めるのではなく、古いものから閉じる**。
+  //    新しい接続を拒むと「使えない」だけで原因が見えないが、
+  //    古いものを閉じれば動き続けたうえで積み上がりも止まる。
+  if (maxSessions > 0 && entries.length - doomed.size > maxSessions) {
+    // 上限は**守らないと箱が落ちる**ので、開いていても切る。
+    // ただし**開いていないものから先に**切る(使っている人を最後まで残す)。
+    const alive = entries.filter(([sid]) => !doomed.has(sid))
+      .sort((a, b) => (a[2] === 0 ? 0 : 1) - (b[2] === 0 ? 0 : 1) || a[1] - b[1]);
+    for (const [sid] of alive.slice(0, alive.length - maxSessions)) doomed.add(sid);
+  }
+
+  // 古い順に返す（ログが読みやすい）
+  return entries.filter(([sid]) => doomed.has(sid)).sort((a, b) => a[1] - b[1]).map(([sid]) => sid);
+}
+
+/**
+ * セッション数の上限を、**接続数から決める**。
+ *
+ * 1 セッションは backend ごとに接続を 1 本ずつ持つので、
+ * 本当のコストは「セッション数 × backend 数」。セッション数で上限を置くと、
+ * backend が増えたときに黙って壊れる(実際に backend 79 件で 15,800 接続になった)。
+ *
+ * @param {number} explicit 明示された maxSessions(0 なら未指定)
+ * @param {number} maxConns 許す接続数
+ * @param {number} backends いま繋いでいる backend の数
+ * @returns {number} 0 なら上限なし
+ */
+export function sessionCap(explicit, maxConns, backends) {
+  if (explicit > 0) return explicit;
+  if (!(maxConns > 0)) return 0;
+  // backend が 0 でも 1 本は使う勘定にする(0 除算を作らない)
+  const per = Math.max(1, Number(backends) || 1);
+  // 最低 4 は残す。**上限のせいで誰も使えない状態を作らない**
+  return Math.max(4, Math.floor(maxConns / per));
+}
+
+/**
+ * 定期的に回収する。返り値を呼ぶと止まる。
+ * @param {object} o
+ * @param {Map<string,{lastSeen:number}>} o.sessions
+ * @param {(sid:string)=>void} o.close  1 件閉じる
+ * @param {number} o.idleMs
+ * @param {number} o.sweepMs
+ * @param {number} o.maxSessions
+ * @param {(n:number, sids:string[])=>void} [o.onReap] 掃除したときに呼ばれる（ログ用）
+ */
+export function startSessionReaper({ sessions, close, idleMs, sweepMs, maxSessions, onReap }) {
+  if (sweepMs <= 0) return () => {};
+  const timer = setInterval(() => {
+    // 関数で渡されたら毎回評価する(backend 数は動く)
+    const cap = typeof maxSessions === 'function' ? maxSessions() : maxSessions;
+    const sids = pickExpired(sessions, { now: Date.now(), idleMs, maxSessions: cap });
+    if (!sids.length) return;
+    for (const sid of sids) {
+      try { close(sid); } catch { /* 1 件の失敗で掃除を止めない */ }
+    }
+    // **黙って閉じない。** 使っていた人には「消えた」ように見えるので、理由を残す
+    onReap?.(sids.length, sids);
+  }, sweepMs);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+export NODE_OPTIONS="--max-old-space-size=1536 ${NODE_OPTIONS:-}"  # 常駐サイズの明示(volta-index#48)
 set -euo pipefail
-cd "$(dirname "$0")/.."
-exec node mcp/server.mjs
+cd "$(dirname "$0")"
+exec /home/opa/.nvm/versions/node/v20.20.0/bin/node mcp/server.mjs


### PR DESCRIPTION
WSL の逼迫を調べていて見つけました。

**本体（java）は 5MB で健全です。** 太っていたのは同居している MCP サーバ（node、ポート 9211）でした。

```
java -jar volta-auth-proxy-0.3.0-SNAPSHOT.jar     5 MB / 115 時間  ← 健全
node mcp/server.mjs                           2,043 MB / 3.6 時間  ← 570MB/時
```

## 原因

Streamable HTTP は要求ごとの往復なので、クライアントが黙って居なくなっても `onclose` が来ません。`transports` に入れた transport と McpServer が丸ごと残りますが、**捨てる仕組みがありませんでした**。

同じ形の漏れを volta-mcp（#15/#17/#23）と narravit（#20）でも直したところなので、同じ直し方を当てています。

## 直したこと

- **放置されたセッションを回収する**（既定 10 分 / 最大 32）
- **開いたままの stream（SSE）は「生きている」として切らない** — 要求が来ないだけで放置ではありません。ここを間違えると繋がっているクライアントを切って再接続させ、**かえって積み上げます**（volta-mcp#23 で実際に踏みました）
- **ヒープ上限を明示**（1536MB）
- **SDK 1.30.0 の `_streamMapping` リークにパッチ**（`node_modules` なので commit 対象外）

## 確認

```
再起動後 75MB / :9211 HTTP 200
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)