### PR TITLE
fix(scim): enforce tenant scope on user updates

### DIFF
--- a/src/main/java/org/unlaxer/infra/volta/ScimRouter.java
+++ b/src/main/java/org/unlaxer/infra/volta/ScimRouter.java
@@ -66,22 +66,24 @@ public final class ScimRouter {
 
         app.put("/scim/v2/Users/{id}", ctx -> {
             JsonNode body = objectMapper.readTree(ctx.body());
+            UUID tenantId = scimTenantId(ctx, body);
             UUID userId = UUID.fromString(ctx.pathParam("id"));
             String email = body.path("userName").asText();
             String displayName = body.path("name").path("formatted").asText(email);
             boolean active = body.path("active").asBoolean(true);
-            int updated = store.updateScimUser(userId, email, displayName, active);
+            int updated = store.updateScimUser(tenantId, userId, email, displayName, active);
             if (updated == 0) throw new ApiException(404, "NOT_FOUND", "SCIM user not found");
             ctx.json(Map.of("id", userId.toString(), "userName", email, "active", active));
         });
 
         app.patch("/scim/v2/Users/{id}", ctx -> {
             JsonNode body = objectMapper.readTree(ctx.body());
+            UUID tenantId = scimTenantId(ctx, body);
             UUID userId = UUID.fromString(ctx.pathParam("id"));
             String email = body.path("userName").asText("patched-" + userId + "@example.local");
             String displayName = body.path("displayName").asText("patched");
             boolean active = body.path("active").asBoolean(true);
-            int updated = store.updateScimUser(userId, email, displayName, active);
+            int updated = store.updateScimUser(tenantId, userId, email, displayName, active);
             if (updated == 0) throw new ApiException(404, "NOT_FOUND", "SCIM user not found");
             ctx.json(Map.of("id", userId.toString(), "active", active));
         });
@@ -96,5 +98,10 @@ public final class ScimRouter {
 
         app.get("/scim/v2/Groups", ctx -> ctx.json(Map.of("schemas", List.of("urn:ietf:params:scim:api:messages:2.0:ListResponse"), "Resources", List.of())));
         app.post("/scim/v2/Groups", ctx -> ctx.status(201).json(Map.of("id", SecurityUtils.newUuid().toString(), "displayName", "group")));
+    }
+
+    private UUID scimTenantId(io.javalin.http.Context ctx, JsonNode body) {
+        String tenantId = body.path("tenantId").asText(ctx.queryParam("tenantId"));
+        return UUID.fromString(tenantId);
     }
 }

--- a/src/main/java/org/unlaxer/infra/volta/SqlStore.java
+++ b/src/main/java/org/unlaxer/infra/volta/SqlStore.java
@@ -2210,17 +2210,21 @@ public final class SqlStore {
         }
     }
 
-    public int updateScimUser(UUID userId, String email, String displayName, boolean active) {
+    public int updateScimUser(UUID tenantId, UUID userId, String email, String displayName, boolean active) {
         try (Connection conn = dataSource.getConnection();
              PreparedStatement ps = conn.prepareStatement("""
                      UPDATE users
                      SET email = ?, display_name = ?, is_active = ?
-                     WHERE id = ?
+                     WHERE id = ? AND EXISTS (
+                         SELECT 1 FROM memberships m
+                         WHERE m.user_id = users.id AND m.tenant_id = ?
+                     )
                      """)) {
             ps.setString(1, email);
             ps.setString(2, displayName);
             ps.setBoolean(3, active);
             ps.setObject(4, userId);
+            ps.setObject(5, tenantId);
             return ps.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Closes #79

## Summary
- Require tenantId from the SCIM PUT/PATCH body or query parameter.
- Restrict user updates to users with a membership in that tenant.
- Return the existing not-found response when the user is outside the requested tenant.

## Verification
- `git diff --check` passes.
- `mvn test` could not start because Java/JAVA_HOME is unavailable in the runner environment.