### PR TITLE
fix(geoip): reject non-IP template values

### DIFF
--- a/src/main/java/org/unlaxer/infra/volta/GeoIpResolver.java
+++ b/src/main/java/org/unlaxer/infra/volta/GeoIpResolver.java
@@ -1,6 +1,7 @@
 package org.unlaxer.infra.volta;
 
 import java.net.URI;
+import java.net.InetAddress;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -109,6 +110,7 @@ final class HttpGeoIpResolver implements GeoIpResolver {
     }
 
     private Optional<GeoInfo> doLookup(String ip) {
+        if (!isIpLiteral(ip)) return Optional.empty();
         String url = urlTemplate.replace("{ip}", ip);
         try {
             HttpRequest req = HttpRequest.newBuilder(URI.create(url))
@@ -169,5 +171,24 @@ final class HttpGeoIpResolver implements GeoIpResolver {
         }
         if (ip.startsWith("fc") || ip.startsWith("fd") || ip.startsWith("fe80")) return true; // RFC 4193 / link-local
         return false;
+    }
+
+    /** Accept only numeric IPv4 or IPv6 literals; never pass header data to a URL template. */
+    static boolean isIpLiteral(String ip) {
+        if (ip == null || ip.isBlank()) return false;
+        try {
+            if (ip.indexOf(':') >= 0) {
+                return InetAddress.getByName(ip).getAddress().length == 16;
+            }
+            String[] octets = ip.split("\\.", -1);
+            if (octets.length != 4) return false;
+            for (String octet : octets) {
+                if (octet.isEmpty() || !octet.chars().allMatch(Character::isDigit)
+                        || Integer.parseInt(octet) > 255) return false;
+            }
+            return InetAddress.getByName(ip).getAddress().length == 4;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/src/test/java/org/unlaxer/infra/volta/GeoIpResolverTest.java
+++ b/src/test/java/org/unlaxer/infra/volta/GeoIpResolverTest.java
@@ -99,6 +99,14 @@ class GeoIpResolverTest {
     }
 
     @Test
+    void rejectsNonIpInputBeforeTemplateExpansion() {
+        assertFalse(HttpGeoIpResolver.isIpLiteral("x&callback=http://attacker.example/"));
+        assertFalse(HttpGeoIpResolver.isIpLiteral("localhost"));
+        assertTrue(HttpGeoIpResolver.isIpLiteral("8.8.8.8"));
+        assertTrue(HttpGeoIpResolver.isIpLiteral("2001:db8::1"));
+    }
+
+    @Test
     void fromEnvWithoutUrlReturnsNoop() {
         // We can't easily unset env vars in JVM, but the method returns NOOP
         // when GEOIP_API_URL is unset. Current test env shouldn't have it.


### PR DESCRIPTION
Closes #81

## Summary
- Validate GeoIP lookup input as an IPv4 or IPv6 literal before expanding the configured URL template.
- Prevent X-Forwarded-For values containing query/path injection characters from reaching the upstream URL.
- Add regression coverage for malicious and valid inputs.

## Verification
- `git diff --check` passes.
- `mvn test` could not start because Java/JAVA_HOME is unavailable in the runner environment.